### PR TITLE
💚 Authenticate Requests to Fix Rate Limits in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,6 +22,7 @@ jobs:
           version: 'latest'
           java-version: '17'
           components: 'native-image'
+          github-token: ${{ secrets.github_token }}
       - uses: gradle/gradle-build-action@v2
         env:
           ORG_GRADLE_PROJECT_pixeeArtifactoryUsername: ${{ secrets.PIXEE_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           version: 'latest'
           java-version: '17'
           components: 'native-image'
+          github-token: ${{ secrets.github_token }}
       - uses: gradle/gradle-build-action@v2
         with:
           arguments: -q setVersion -PnewVersion=${{ inputs.version }}


### PR DESCRIPTION
The `setup/graalvm` action makes some requests to GitHub APIs, and authenticating those requests raises the ceiling on GitHub rate limiting.