### PR TITLE
Fix DefaultRuleSetting not getting exported

### DIFF
--- a/languages/java/build.gradle.kts
+++ b/languages/java/build.gradle.kts
@@ -70,10 +70,11 @@ dependencies {
     implementation(libs.progressbar)
     implementation(libs.slf4j.api)
 
-    implementation(project(":languages:codemodder-semgrep-provider"))
-    implementation(project(":languages:codemodder-common"))
-    implementation(project(":languages:codemodder-framework-java"))
-    implementation(project(":languages:codemodder-default-codemods"))
+    api(project(":languages:codemodder-common"))
+    api(project(":languages:codemodder-semgrep-provider"))
+    api(project(":languages:codemodder-common"))
+    api(project(":languages:codemodder-framework-java"))
+    api(project(":languages:codemodder-default-codemods"))
 
     testCompileOnly(libs.jetbrains.annotations)
 


### PR DESCRIPTION
The public types of `codemodder-common` and other internal project dependencies that are _supposed_ to be public and transitively included were being marked as `runtime` when being published to Maven. This should fix that.