### PR TITLE
Add more verbose output

### DIFF
--- a/languages/java/src/main/java/io/openpixee/java/JavaFixitCliRun.java
+++ b/languages/java/src/main/java/io/openpixee/java/JavaFixitCliRun.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.time.StopWatch;
@@ -114,8 +113,6 @@ public final class JavaFixitCliRun {
                     .collect(Collectors.toList())));
 
     LOG.debug("Scanning following files: {}", allJavaFiles.size());
-
-    new Random();
 
     List<Class<? extends Changer>> defaultCodemodTypes = DefaultCodemods.asList();
     CodemodInvoker codemodInvoker =


### PR DESCRIPTION
We are getting an exit code of 1 from Semgrep when running from within the container:

```
java.lang.RuntimeException: error code seen from semgrep execution: 1
at io.codemodder.providers.sarif.semgrep.DefaultSemgrepRunner.run(DefaultSemgrepRunner.java:48)
at io.codemodder.providers.sarif.semgrep.SemgrepModule.configure(SemgrepModule.java:96)
```

This option adds the `--no-error` flag to Semgrep to make sure it isn't somehow getting set accidentally and makes sure all I/O is redirected to stdout/stderr of the running process.