### PR TITLE
Add ability to specify semgrep yaml inline

### DIFF
--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepScan.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepScan.java
@@ -18,9 +18,12 @@ import javax.inject.Qualifier;
 @Target(ElementType.PARAMETER)
 public @interface SemgrepScan {
 
+  /** A YAML string that represents Semgrep rule(s). */
+  String yaml() default "";
+
   /**
-   * The classpath resource path of the type. It is assumed the path will be in the same package as
-   * the {@link Codemod}.
+   * The classpath resource path of the Semgrep YAML file. It is assumed the path will be in the
+   * same package as the {@link Codemod}.
    *
    * <p>So, for instance, if you had a codemod in <code>com.acme.codemods</code>, and a YAML rule
    * file in /com/acme/codemods/my-rule.yaml, you would simply specify "my-rule.yaml" for this

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepJavaParserChangerTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepJavaParserChangerTest.java
@@ -3,12 +3,12 @@ package io.codemodder.providers.sarif.semgrep;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.contrastsecurity.sarif.Result;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.google.inject.CreationException;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import io.codemodder.*;
@@ -24,14 +24,17 @@ import org.junit.jupiter.api.io.TempDir;
 
 final class SemgrepJavaParserChangerTest {
 
+  private static final String FINDS_THAT_SEMGREP_YAML =
+      "rules:\n  - id: inline-semgrep\n    pattern: new Stuff()\n    languages:\n      - java\n    message: Semgrep found a match\n    severity: WARNING\n";
+
   @Codemod(
       author = "pixee",
       id = "pixee-test:java/finds-stuff",
       reviewGuidance = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW)
-  static class FindsStuffCodemod extends SarifPluginJavaParserChanger<ObjectCreationExpr> {
+  static class ExplicitPathCodemod extends SarifPluginJavaParserChanger<ObjectCreationExpr> {
 
     @Inject
-    FindsStuffCodemod(
+    ExplicitPathCodemod(
         @SemgrepScan(
                 pathToYaml = "/other_dir/explicit-yaml-path.yaml",
                 ruleId = "explicit-yaml-path")
@@ -50,25 +53,35 @@ final class SemgrepJavaParserChangerTest {
   }
 
   @Test
-  void it_gives_visitor_when_findings_present(@TempDir Path tmpDir) throws IOException {
+  void it_gives_sarif_off_explicit_yaml_path(@TempDir Path tmpDir) throws IOException {
     String javaCode = "class Foo { \n\n  Object a = new Stuff(); \n }";
     Path javaFile = writeJavaFile(tmpDir, javaCode);
 
-    SemgrepModule module = new SemgrepModule(tmpDir, List.of(FindsStuffCodemod.class));
+    SemgrepModule module = new SemgrepModule(tmpDir, List.of(ExplicitPathCodemod.class));
     Injector injector = Guice.createInjector(module);
-    FindsStuffCodemod instance = injector.getInstance(FindsStuffCodemod.class);
+    ExplicitPathCodemod instance = injector.getInstance(ExplicitPathCodemod.class);
     RuleSarif ruleSarif = instance.sarif;
     assertThat(ruleSarif, is(notNullValue()));
     assertThat(ruleSarif.getRegionsFromResultsByRule(javaFile).size(), is(1));
+  }
 
-    CodeDirectory directory = mock(CodeDirectory.class);
-    when(directory.asPath()).thenReturn(tmpDir);
+  @Test
+  void it_gives_sarif_off_inline_yaml(@TempDir Path tmpDir) throws IOException {
+    String javaCode = "class Foo { \n\n  Object a = new Stuff();\n  Object b = new That();\n }";
+    Path javaFile = writeJavaFile(tmpDir, javaCode);
 
-    CodemodInvocationContext context = mock(CodemodInvocationContext.class);
-    when(context.codemodId()).thenReturn("pixee-test:java/finds-stuff");
-    when(context.path()).thenReturn(javaFile);
-    when(context.codeDirectory()).thenReturn(directory);
-    when(context.changeRecorder()).thenReturn(mock(FileWeavingContext.class));
+    SemgrepModule module = new SemgrepModule(tmpDir, List.of(UsesInlineSemgrepCodemod.class));
+    Injector injector = Guice.createInjector(module);
+    UsesInlineSemgrepCodemod instance = injector.getInstance(UsesInlineSemgrepCodemod.class);
+    RuleSarif ruleSarif = instance.sarif;
+    assertThat(ruleSarif, is(notNullValue()));
+    assertThat(ruleSarif.getRegionsFromResultsByRule(javaFile).size(), is(1));
+  }
+
+  @Test
+  void it_fails_when_both_used(@TempDir Path tmpDir) {
+    SemgrepModule module = new SemgrepModule(tmpDir, List.of(InvalidUsesBothYamlStrategies.class));
+    assertThrows(CreationException.class, () -> Guice.createInjector(module));
   }
 
   private Path writeJavaFile(final Path tmpDir, final String javaCode) throws IOException {
@@ -76,5 +89,55 @@ final class SemgrepJavaParserChangerTest {
     Files.write(
         javaFile, javaCode.getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING);
     return javaFile;
+  }
+
+  @Codemod(
+      author = "pixee",
+      id = "pixee-test:java/uses-inline-semgrep",
+      reviewGuidance = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW)
+  static class UsesInlineSemgrepCodemod extends SarifPluginJavaParserChanger<ObjectCreationExpr> {
+
+    @Inject
+    UsesInlineSemgrepCodemod(
+        @SemgrepScan(yaml = FINDS_THAT_SEMGREP_YAML, ruleId = "inline-semgrep")
+            RuleSarif ruleSarif) {
+      super(ruleSarif, ObjectCreationExpr.class);
+    }
+
+    @Override
+    public boolean onResultFound(
+        final CodemodInvocationContext context,
+        final CompilationUnit cu,
+        final ObjectCreationExpr node,
+        final Result result) {
+      return true;
+    }
+  }
+
+  @Codemod(
+      author = "pixee",
+      id = "pixee-test:java/both-yaml",
+      reviewGuidance = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW)
+  static class InvalidUsesBothYamlStrategies
+      extends SarifPluginJavaParserChanger<ObjectCreationExpr> {
+
+    @Inject
+    InvalidUsesBothYamlStrategies(
+        @SemgrepScan(
+                yaml = FINDS_THAT_SEMGREP_YAML,
+                pathToYaml = "/other_dir/explicit-yaml-path.yaml",
+                ruleId = "explicit-yaml-path")
+            RuleSarif ruleSarif) {
+      super(ruleSarif, ObjectCreationExpr.class);
+    }
+
+    @Override
+    public boolean onResultFound(
+        final CodemodInvocationContext context,
+        final CompilationUnit cu,
+        final ObjectCreationExpr node,
+        final Result result) {
+      return true;
+    }
   }
 }


### PR DESCRIPTION
When writing docs, it felt really awkward for "my first codemod" to be covered in minutiae about files, classpath paths, default location, etc., for a "hello world" codemod.

This change gives us the ability to specify Semgrep YAML inline in the Java class of the codemod. 