### PR TITLE
Cleans up dependencies

### DIFF
--- a/plugins/codemodder-plugin-maven/build.gradle.kts
+++ b/plugins/codemodder-plugin-maven/build.gradle.kts
@@ -14,6 +14,10 @@ dependencies {
     compileOnly(libs.jetbrains.annotations)
     implementation("io.codemodder:codemodder-core")
     implementation("io.openpixee.maven:pom-operator:0.0.7") // TODO bring into monorepo
+    {
+        exclude(group = "com.google.inject", module = "guice")
+    }
+    implementation("com.google.inject:guice:5.1.0")
 
     testImplementation(testlibs.bundles.junit.jupiter)
     testImplementation(testlibs.bundles.hamcrest)


### PR DESCRIPTION
`pom-operator` version `0.0.7` cleans up dependencies. This PR exposes those changes by actually removing the explicit dependency control made previously