### PR TITLE
⚡️ Process Lines of Interest Stream-Wise

### DIFF
--- a/codemodder-community-codemods/src/main/java/io/codemodder/codemods/SensitiveDataLoggingCodemod.java
+++ b/codemodder-community-codemods/src/main/java/io/codemodder/codemods/SensitiveDataLoggingCodemod.java
@@ -6,15 +6,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.theokanning.openai.service.OpenAiService;
 import io.codemodder.Codemod;
 import io.codemodder.CodemodInvocationContext;
+import io.codemodder.Line;
 import io.codemodder.ReviewGuidance;
 import io.codemodder.plugins.llm.OpenAIGPT35TurboCodeChanger;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 import javax.inject.Inject;
 
 /** A cross-language codemod that removes any sensitive data being logged. */
@@ -24,36 +22,33 @@ import javax.inject.Inject;
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
 public final class SensitiveDataLoggingCodemod extends OpenAIGPT35TurboCodeChanger {
 
-  @VisibleForTesting
-  static final Pattern loggingCallPattern =
-      Pattern.compile("log(ger)?.(info|warn|error|fatal)", Pattern.CASE_INSENSITIVE);
-
   @Inject
   public SensitiveDataLoggingCodemod(final OpenAiService openAIService) {
     super(openAIService);
   }
 
   @Override
-  protected Set<Integer> findLinesOfInterest(final CodemodInvocationContext context)
+  protected IntStream findLinesOfInterest(final CodemodInvocationContext context)
       throws IOException {
-    List<String> fileContent = Files.readAllLines(context.path());
-    List<String> keywords = List.of("password", "secret", "token", "key", "credentials", "ssn");
-    Set<Integer> linesToReview = new HashSet<>();
-    for (int i = 0; i < fileContent.size(); i++) {
-      String line = fileContent.get(i);
-      Matcher matcher = loggingCallPattern.matcher(line);
-      boolean isMatch =
-          matcher.find()
-              && keywords.stream().anyMatch(keyword -> containsIgnoreCase(line, keyword));
-      if (isMatch) {
-        linesToReview.add(i + 1);
-      }
-    }
-    return linesToReview;
+    return context
+        .lines()
+        .filter(
+            line ->
+                loggingCallPattern.matcher(line.content()).find()
+                    && KEYWORDS.stream()
+                        .anyMatch(keyword -> containsIgnoreCase(line.content(), keyword)))
+        .mapToInt(Line::number);
   }
 
   @Override
   protected String getUserPrompt() {
     return "I want to check if this code is logging sensitive data, like passwords, access tokens, API keys, session IDs, SSNs, or something similarly sensitive and remove the log statement if so. Make sure if you fix it, you remove only that statement. I am providing other lines just to give you context. I am worried about string variables.";
   }
+
+  @VisibleForTesting
+  static final Pattern loggingCallPattern =
+      Pattern.compile("log(ger)?.(info|warn|error|fatal)", Pattern.CASE_INSENSITIVE);
+
+  private static final List<String> KEYWORDS =
+      List.of("password", "secret", "token", "key", "credentials", "ssn");
 }

--- a/framework/codemodder-core/src/main/java/io/codemodder/CodemodInvocationContext.java
+++ b/framework/codemodder-core/src/main/java/io/codemodder/CodemodInvocationContext.java
@@ -1,6 +1,10 @@
 package io.codemodder;
 
+import com.google.common.collect.Streams;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 /** The context we provide to each codemod. */
 public interface CodemodInvocationContext {
@@ -16,4 +20,16 @@ public interface CodemodInvocationContext {
 
   /** The ID of the codemod changing the file. */
   String codemodId();
+
+  /**
+   * Convenience method for stream-wise processing lines of the file being changed with line
+   * numbers.
+   *
+   * @return {@link Stream} of lines (with indices) of the file being changed. Must be closed.
+   * @throws IOException when fails to read the file
+   */
+  default Stream<Line> lines() throws IOException {
+    return Streams.mapWithIndex(
+        Files.lines(path()), (content, line) -> new DefaultLine((int) line, content));
+  }
 }

--- a/framework/codemodder-core/src/main/java/io/codemodder/DefaultLine.java
+++ b/framework/codemodder-core/src/main/java/io/codemodder/DefaultLine.java
@@ -1,0 +1,49 @@
+package io.codemodder;
+
+import java.util.Objects;
+
+/**
+ * Value type implementation of {@link Line}. We should replace this with a {@code record} when we
+ * upgrade to JDK 16+. This is a temporary workaround to avoid depending on JDK 16+.
+ */
+final class DefaultLine implements Line {
+
+  private final int number;
+  private final String content;
+
+  DefaultLine(int number, String content) {
+    if (number <= 0) {
+      throw new IllegalArgumentException("Line number must be positive");
+    }
+    this.number = number;
+    this.content = Objects.requireNonNull(content);
+  }
+
+  @Override
+  public int number() {
+    return number;
+  }
+
+  @Override
+  public String content() {
+    return content;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    DefaultLine that = (DefaultLine) o;
+
+    if (number != that.number) return false;
+    return content.equals(that.content);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = number;
+    result = 31 * result + content.hashCode();
+    return result;
+  }
+}

--- a/framework/codemodder-core/src/main/java/io/codemodder/Line.java
+++ b/framework/codemodder-core/src/main/java/io/codemodder/Line.java
@@ -1,0 +1,14 @@
+package io.codemodder;
+
+/** Represents a line of code. */
+public interface Line {
+  /**
+   * @return the line number, starting from 1
+   */
+  int number();
+
+  /**
+   * @return the content of the line
+   */
+  String content();
+}


### PR DESCRIPTION
Avoids reading the entire file into memory to find the lines of interest. I'm not as concerned about the `String code = Files.readString(context.path());` in `OpenAIGPT35TurboCodeChanger`, because that's an implementation detail that we can change later without the codemod author being aware.