### PR TITLE
🧱 Replace iulspop/special-base-image With JDK 17 Base Image

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -1,0 +1,33 @@
+name: Base Container Image
+
+env:
+  AWS_REGION: "us-east-1"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push:
+    name: Build & Push Base Container Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Fetch AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::218200003247:role/DeployCodemodderImagesRole
+          role-session-name: github
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build & Push Base Image
+        run: |
+          docker buildx build --push -t ${{ steps.login-ecr.outputs.registry }}/pixee/codemodder-java:base-image .
+        working-directory: base-image

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,0 +1,2 @@
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:17
+RUN yum install -y python3 python3-pip && python3 -m pip install semgrep

--- a/gradle/build-plugins/src/main/kotlin/io.codemodder.container-publish.gradle.kts
+++ b/gradle/build-plugins/src/main/kotlin/io.codemodder.container-publish.gradle.kts
@@ -3,4 +3,4 @@ plugins {
     id("com.google.cloud.tools.jib")
 }
 
-jib.from.image = "iulspop/special-base-image"
+jib.from.image = "218200003247.dkr.ecr.us-east-1.amazonaws.com/pixee/codemodder-java:base-image"


### PR DESCRIPTION
We no longer have access to iulspop/special-base-image, and we want to upgrade this base image to use Java 17 instead of 11. The new, manually triggered workflow builds the new base image and deploys it to our private ECR.