### PR TITLE
🥅 Provide API for Capturing Error Code and Console Output

### DIFF
--- a/framework/codemodder-core/src/main/java/io/codemodder/Runner.java
+++ b/framework/codemodder-core/src/main/java/io/codemodder/Runner.java
@@ -1,5 +1,6 @@
 package io.codemodder;
 
+import java.io.PrintWriter;
 import java.util.List;
 import picocli.CommandLine;
 
@@ -7,20 +8,39 @@ import picocli.CommandLine;
 public final class Runner {
 
   /**
-   * Runs the codemods built in the codemodder framework.
+   * Runs the default, Pixee-developed codemods.
    *
    * @param codemods The codemods to run
    * @param args The arguments to pass to the codemod runner
+   * @param stdout alternate stdout to use, or {@code null} to use the default
+   * @param stderr alternate stderr to use, or {@code null} to use the default
+   * @return the exit code of the codemodder CLI
    */
-  public static void run(final List<Class<? extends CodeChanger>> codemods, final String[] args) {
+  public static int run(
+      final List<Class<? extends CodeChanger>> codemods,
+      final String[] args,
+      final PrintWriter stdout,
+      final PrintWriter stderr) {
     CommandLine commandLine =
         new CommandLine(new CLI(args, codemods)).setCaseInsensitiveEnumValuesAllowed(true);
-    int exitCode = commandLine.execute(args);
+    if (stdout != null) {
+      commandLine.setOut(stdout);
+    }
+    if (stderr != null) {
+      commandLine.setErr(stderr);
+    }
+    return commandLine.execute(args);
+  }
 
+  /**
+   * @see #run(List, String[], PrintWriter, PrintWriter)
+   */
+  public static void run(final List<Class<? extends CodeChanger>> codemods, final String[] args) {
+    final int code = run(codemods, args, null, null);
     // we honor a special exit code (-1) that tells us not to exit, this is useful for integration
     // tests
-    if (exitCode != -1) {
-      System.exit(exitCode);
+    if (code != -1) {
+      System.exit(code);
     }
   }
 }

--- a/framework/codemodder-core/src/test/java/io/codemodder/CLITest.java
+++ b/framework/codemodder-core/src/test/java/io/codemodder/CLITest.java
@@ -9,6 +9,8 @@ import io.codemodder.codetf.CodeTFReport;
 import io.codemodder.codetf.CodeTFResult;
 import io.codemodder.javaparser.JavaParserFactory;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -46,6 +48,23 @@ final class CLITest {
             SourceDirectory.createDefault(
                 tmpDir.resolve("module2/src/main/java").toAbsolutePath(),
                 List.of(barJavaFile.toAbsolutePath().toString())));
+  }
+
+  /**
+   * Runs the CLI with arguments that we know will cause it to fail, and asserts that the exit code
+   * denotes failure and an error message is captured in the alternative stderr stream.
+   */
+  @Test
+  void it_captures_console_output() {
+    final var args = new String[] {"--bogus"};
+    final var stdoutWriter = new StringWriter();
+    final var stderrWriter = new StringWriter();
+    try (var stdout = new PrintWriter(stdoutWriter);
+        var stderr = new PrintWriter(stderrWriter)) {
+      final var code = Runner.run(List.of(Cloud9Changer.class), args, stdout, stderr);
+      assertThat(code).isEqualTo(2);
+    }
+    assertThat(stderrWriter.toString()).startsWith("Unknown option: '--bogus'");
   }
 
   @Test


### PR DESCRIPTION
Method overload in Runner allows a caller like pixeebot to capture console output and the error code. This is also useful for testing.