### PR TITLE
Removed unflippable methods

### DIFF
--- a/codemodder-community-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
+++ b/codemodder-community-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import io.codemodder.*;
 import io.codemodder.providers.sarif.pmd.PmdScan;
+import java.util.Set;
 import javax.inject.Inject;
 
 /**
@@ -32,10 +33,18 @@ public final class SwitchLiteralFirstComparisonsCodemod
       final CompilationUnit cu,
       final MethodCallExpr methodCallExpr,
       final Result result) {
+    // some of the methods that this rule applies to are not flippable, like compareTo() would
+    // change the logic after
+    if (!flippableComparisonMethods.contains(methodCallExpr.getNameAsString())) {
+      return false;
+    }
     Expression leftSide = methodCallExpr.getScope().get();
     Expression rightSide = methodCallExpr.getArgument(0);
     methodCallExpr.setScope(rightSide);
     methodCallExpr.setArgument(0, leftSide);
     return true;
   }
+
+  private static final Set<String> flippableComparisonMethods =
+      Set.of("equals", "equalsIgnoreCase", "contentEquals");
 }

--- a/codemodder-community-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.after
+++ b/codemodder-community-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.after
@@ -11,7 +11,7 @@ final class Test {
        boolean change1 = "bar".equals(foo);
        if("bar".equals(foo)) { // should change
            System.out.println("foo");
-       } else if("bar".compareTo(foo)) { // change
+       } else if(foo.compareTo("bar") > 0) { // shouldn't change, can't mess with compareTo
            System.out.println("foo");
        } else if("foo".equals(bar)) { // should be fine
            System.out.println("foo");

--- a/codemodder-community-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.before
+++ b/codemodder-community-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.before
@@ -11,7 +11,7 @@ final class Test {
        boolean change1 = foo.equals("bar");
        if(foo.equals("bar")) { // should change
            System.out.println("foo");
-       } else if(foo.compareTo("bar")) { // change
+       } else if(foo.compareTo("bar") > 0) { // shouldn't change, can't mess with compareTo
            System.out.println("foo");
        } else if("foo".equals(bar)) { // should be fine
            System.out.println("foo");


### PR DESCRIPTION
While writing docs for the "switch literals first", I realized I had prevent changing in situations in which the order _does_ in fact affect the code flow. For instance, this code:


```
if (bar.compareTo("thing") < 1) {
```

If I flip `bar` and `"thing"` then the logic will be wrong because the numerical comparison would need a corresponding change. For now, we'll just do the simple thing and only fix when its known to be completely safe as is.