### PR TITLE
feat(CLI): `--verbose` enables debug logging

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -1,5 +1,7 @@
 package io.codemodder;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javaparser.JavaParser;
@@ -179,6 +181,10 @@ final class CLI implements Callable<Integer> {
 
   @Override
   public Integer call() throws IOException {
+    if (verbose) {
+      LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+      context.getLogger(LoggingConfigurator.OUR_ROOT_LOGGER_NAME).setLevel(Level.DEBUG);
+    }
 
     if (listCodemods) {
       for (Class<? extends CodeChanger> codemodType : codemodTypes) {


### PR DESCRIPTION
As more folks start getting exposed to the CLI, being able to enable debug logging using `--verbose` seems like it'll be a valuable troubleshooting tool. 

There may be a more elegant solution for this, but this does seem to do the trick.

BTW the JavaDoc for `LoggingConfigurator` states:
> A configurator for the log levels that defaults to "quiet" mode. This can be updated by using the "-v" (verbose) command line setting.

Does that need to get updated too?