### PR TITLE
fix(LLMAssistedCodemod): line number in CodeTF is off by 1

### DIFF
--- a/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/LLMAssistedCodemod.java
+++ b/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/LLMAssistedCodemod.java
@@ -109,9 +109,9 @@ public abstract class LLMAssistedCodemod extends SarifPluginRawFileChanger {
         throw new UncheckedIOException(e);
       }
 
-      return List.of(
-          CodemodChange.from(
-              patch.getDeltas().get(0).getSource().getPosition(), fix.getFixDescription()));
+      // Report all the changes at the line number of the first change.
+      int line = patch.getDeltas().get(0).getSource().getPosition() + 1; // Position is 0-based.
+      return List.of(CodemodChange.from(line, fix.getFixDescription()));
     } catch (Exception e) {
       logger.error("failed to process: {}", context.path(), e);
       throw e;


### PR DESCRIPTION
The line number of the change was being set to the position of the first delta, but the position is 0-based.  For example:
```java
Patch<String> patch = DiffUtils.diff(List.of("hello"), List.of("goodbye"));
System.out.println(patch.toString());
```

Results in a position of `0` instead of `1`:
```
Patch{deltas=[[ChangeDelta, position: 0, lines: [hello] to [goodbye]]]}
```

We now add 1 to the position to get the actual line number.