### PR TITLE
Improved and fixed `limit-readline` codemod

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/LimitReadlineCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/LimitReadlineCodemod.java
@@ -31,8 +31,8 @@ public final class LimitReadlineCodemod extends SarifPluginJavaParserChanger<Met
               name = "limit",
               type = CodemodParameter.ParameterType.NUMBER,
               label = "a positive integer",
-              defaultValue = "1000000", // representing roughly 1MB
-              validationPattern = "\\d+")
+              defaultValue = "5_000_000", // representing roughly 5MB
+              validationPattern = "(\\d|\\_)+")
           final Parameter limit) {
     super(sarif, MethodCallExpr.class);
     this.limit = Objects.requireNonNull(limit);

--- a/core-codemods/src/main/java/io/codemodder/codemods/LimitReadlineCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/LimitReadlineCodemod.java
@@ -32,7 +32,7 @@ public final class LimitReadlineCodemod extends SarifPluginJavaParserChanger<Met
               type = CodemodParameter.ParameterType.NUMBER,
               label = "a positive integer",
               defaultValue = "5_000_000", // representing roughly 5MB
-              validationPattern = "(\\d|\\_)+")
+              validationPattern = "[0-9\\_]+")
           final Parameter limit) {
     super(sarif, MethodCallExpr.class);
     this.limit = Objects.requireNonNull(limit);

--- a/core-codemods/src/main/resources/io/codemodder/codemods/LimitReadlineCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/LimitReadlineCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Introduced protections against DoS via unterminated read operations",
+  "summary" : "Protect `readLine()` against DoS",
   "change": "Replaced with a call that offers an upper bound on the number of characters that will be read before giving up and throwing a security exception",
   "control" : "https://github.com/pixee/java-security-toolkit/blob/main/src/main/java/io/github/pixee/security/BoundedLineReader.java",
   "references" : [

--- a/core-codemods/src/test/resources/limit-readline/Test.java.after
+++ b/core-codemods/src/test/resources/limit-readline/Test.java.after
@@ -7,16 +7,16 @@ import java.io.IOException;
 public final class Test {
 
   void stewie2k(BufferedReader br) throws IOException {
-    BoundedLineReader.readLine(br, 1000000);
+    BoundedLineReader.readLine(br, 5_000_000);
   }
 
   void tarik(BufferedReader br) throws IOException {
-    System.out.println(BoundedLineReader.readLine(br, 1000000));
+    System.out.println(BoundedLineReader.readLine(br, 5_000_000));
   }
 
   void skadoodle(final BufferedReader br) {
     try {
-      String a = BoundedLineReader.readLine(br, 1000000);
+      String a = BoundedLineReader.readLine(br, 5_000_000);
       System.out.println(a);
     } catch (IOException e) {
     }


### PR DESCRIPTION
The changes were not in line with the docs (1MB vs 5MB) and the feedback on the title was "too wordy and hard to grok".