### PR TITLE
Work on files outside of traditional source directories

### DIFF
--- a/core-codemods/src/intTest/java/io/codemodder/integration/WebGoat822Test.java
+++ b/core-codemods/src/intTest/java/io/codemodder/integration/WebGoat822Test.java
@@ -88,8 +88,6 @@ final class WebGoat822Test extends GitRepositoryTest {
 
     var report = objectMapper.readValue(new FileReader(outputFile), CodeTFReport.class);
 
-    System.out.println(objectMapper.writeValueAsString(report));
-
     verifyNoFailedFiles(report);
 
     List<CodeTFChangesetEntry> fileChanges =
@@ -97,11 +95,6 @@ final class WebGoat822Test extends GitRepositoryTest {
             .map(CodeTFResult::getChangeset)
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
-
-    fileChanges.stream()
-        .forEach(
-            codeTFChangesetEntry ->
-                System.out.println("change: " + codeTFChangesetEntry.getPath()));
 
     assertThat(fileChanges.size(), is(43));
 
@@ -134,8 +127,6 @@ final class WebGoat822Test extends GitRepositoryTest {
 
     var report = objectMapper.readValue(new FileReader(outputFile), CodeTFReport.class);
 
-    System.out.println(objectMapper.writeValueAsString(report));
-
     verifyNoFailedFiles(report);
 
     List<CodeTFChangesetEntry> fileChanges =
@@ -143,11 +134,6 @@ final class WebGoat822Test extends GitRepositoryTest {
             .map(CodeTFResult::getChangeset)
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
-
-    fileChanges.stream()
-        .forEach(
-            codeTFChangesetEntry ->
-                System.out.println("change: " + codeTFChangesetEntry.getPath()));
 
     assertThat(fileChanges.size(), is(48));
 

--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -390,9 +390,7 @@ final class CLI implements Callable<Integer> {
     if (parameterStrings == null || parameterStrings.isEmpty()) {
       return List.of();
     }
-    return parameterStrings.stream()
-        .map(ParameterArgument::fromNameValuePairs)
-        .collect(Collectors.toUnmodifiableList());
+    return parameterStrings.stream().map(ParameterArgument::fromNameValuePairs).toList();
   }
 
   private static final int SUCCESS = 0;
@@ -412,7 +410,7 @@ final class CLI implements Callable<Integer> {
           "**/web.xml");
 
   private static final List<String> defaultPathExcludes =
-      List.of("**/test/**", "**/target/**", "**/build/**");
+      List.of("**/test/**", "**/target/**", "**/build/**", "**/.mvn/**");
 
   private static final Logger log = LoggerFactory.getLogger(CLI.class);
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -312,7 +312,6 @@ final class CLI implements Callable<Integer> {
       JavaParser javaParser = javaParserFactory.create(sourceDirectories);
       CachingJavaParser cachingJavaParser = CachingJavaParser.from(javaParser);
       for (CodemodIdPair codemod : codemods) {
-        System.out.println("Running codemod: " + codemod.getId());
         CodemodExecutor codemodExecutor =
             new DefaultCodemodExecutor(
                 projectPath,
@@ -410,7 +409,7 @@ final class CLI implements Callable<Integer> {
           "**/web.xml");
 
   private static final List<String> defaultPathExcludes =
-      List.of("**/test/**", "**/target/**", "**/build/**", "**/.mvn/**");
+      List.of("**/test/**", "**/target/**", "**/build/**", "**/.mvn/**", ".mvn/**");
 
   private static final Logger log = LoggerFactory.getLogger(CLI.class);
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -169,15 +169,16 @@ final class CLI implements Callable<Integer> {
   static class DefaultFileFinder implements FileFinder {
     @Override
     public List<Path> findFiles(final Path projectDir, final IncludesExcludes includesExcludes) {
-      List<Path> allFiles = new ArrayList<>();
       final List<Path> allFiles;
       try (Stream<Path> paths = Files.walk(projectDir)) {
-        allFiles = paths
-            .filter(Files::isRegularFile)
-            .filter(p -> !Files.isSymbolicLink(p)) // could cause infinite loop if we follow links
-            .filter(p -> includesExcludes.shouldInspect(p.toFile()))
-            .sorted()
-            .toList();
+        allFiles =
+            paths
+                .filter(Files::isRegularFile)
+                .filter(
+                    p -> !Files.isSymbolicLink(p)) // could cause infinite loop if we follow links
+                .filter(p -> includesExcludes.shouldInspect(p.toFile()))
+                .sorted()
+                .toList();
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }

--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -170,13 +170,14 @@ final class CLI implements Callable<Integer> {
     @Override
     public List<Path> findFiles(final Path projectDir, final IncludesExcludes includesExcludes) {
       List<Path> allFiles = new ArrayList<>();
+      final List<Path> allFiles;
       try (Stream<Path> paths = Files.walk(projectDir)) {
-        paths
+        allFiles = paths
             .filter(Files::isRegularFile)
             .filter(p -> !Files.isSymbolicLink(p)) // could cause infinite loop if we follow links
             .filter(p -> includesExcludes.shouldInspect(p.toFile()))
             .sorted()
-            .forEach(allFiles::add);
+            .toList();
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }

--- a/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
@@ -75,7 +75,6 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
         filePaths.stream().filter(codemodRunner::supports).sorted().toList();
 
     for (Path filePath : codemodTargetFiles) {
-      System.out.println("  Running on file " + filePath.toString());
       // create the context necessary for the codemod to run
       LineIncludesExcludes lineIncludesExcludes =
           includesExcludes.getIncludesExcludesForFile(filePath.toFile());

--- a/framework/codemodder-base/src/main/java/io/codemodder/FileFinder.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/FileFinder.java
@@ -13,10 +13,9 @@ interface FileFinder {
    * be taken into account downstream. The files should be sorted according to a system-dependent
    * method.
    *
-   * @param sourceDirectories the directories to search
+   * @param projectDir the directories to search
    * @param includesExcludes the includes and excludes
    * @return a list of files that match the includes and excludes
    */
-  List<Path> findFiles(List<SourceDirectory> sourceDirectories, IncludesExcludes includesExcludes)
-      throws IOException;
+  List<Path> findFiles(Path projectDir, IncludesExcludes includesExcludes) throws IOException;
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/DefaultJavaParserFactory.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/DefaultJavaParserFactory.java
@@ -7,13 +7,12 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSol
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import io.codemodder.SourceDirectory;
-import java.io.IOException;
 import java.util.List;
 
 final class DefaultJavaParserFactory implements JavaParserFactory {
 
   @Override
-  public JavaParser create(final List<SourceDirectory> sourceDirectories) throws IOException {
+  public JavaParser create(final List<SourceDirectory> sourceDirectories) {
     final JavaParser javaParser = new JavaParser();
     final CombinedTypeSolver combinedTypeSolver = new CombinedTypeSolver();
     combinedTypeSolver.add(new ReflectionTypeSolver());

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserFactory.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserFactory.java
@@ -9,7 +9,9 @@ import java.util.List;
 public interface JavaParserFactory {
 
   /**
-   * Create a JavaParser instance for the given project source directories
+   * Create a JavaParser instance for the given project source directories. Note that we should
+   * still operate on the files that are not in the source directories, but we may have less symbol
+   * resolution for them.
    *
    * @param sourceDirectories the path to the project
    * @return a JavaParser instance based on the given source directories

--- a/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
@@ -48,7 +48,7 @@ final class CLITest {
     Files.write(barJavaFile, "public class Bar {}".getBytes());
 
     /*
-     * Only add module2 to the discovered source directories. This will help prove that the module2 files can still be seen and changed, even if we couldn't locate it as a "source directory".
+     * Only add module2 to the discovered source directories. This will help prove that the module1 files can still be seen and changed, even if we couldn't locate it as a "source directory".
      */
     sourceDirectories =
         List.of(

--- a/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
@@ -37,7 +37,7 @@ final class CLITest {
   void setup(final @TempDir Path tmpDir) throws IOException {
     workingRepoDir = tmpDir;
     Path module1JavaDir =
-        Files.createDirectories(tmpDir.resolve("module1/src/main/java/com/acme/"));
+        Files.createDirectories(tmpDir.resolve("module1/src/alternateMain/java/com/acme/"));
     Path module2JavaDir =
         Files.createDirectories(tmpDir.resolve("module2/src/main/java/com/acme/util/"));
     fooJavaFile = module1JavaDir.resolve("Foo.java");
@@ -46,11 +46,12 @@ final class CLITest {
         fooJavaFile,
         "import com.acme.util.Bar; class Foo {private var bar = new Bar();}".getBytes());
     Files.write(barJavaFile, "public class Bar {}".getBytes());
+
+    /*
+     * Only add module2 to the discovered source directories. This will help prove that the module2 files can still be seen and changed, even if we couldn't locate it as a "source directory".
+     */
     sourceDirectories =
         List.of(
-            SourceDirectory.createDefault(
-                tmpDir.resolve("module1/src/main/java").toAbsolutePath(),
-                List.of(fooJavaFile.toAbsolutePath().toString())),
             SourceDirectory.createDefault(
                 tmpDir.resolve("module2/src/main/java").toAbsolutePath(),
                 List.of(barJavaFile.toAbsolutePath().toString())));
@@ -112,7 +113,7 @@ final class CLITest {
     List<CodeTFResult> dryRunCodeTFResults = dryRunCodeTFReport.getResults();
 
     // we just compare the results because the "run" section is non-deterministic (has elapsed time
-    // etc)
+    // etc.)
     String normalJson = mapper.writeValueAsString(normalCodeTFResults);
     String dryRunJson = mapper.writeValueAsString(dryRunCodeTFResults);
     assertThat(normalJson).isEqualTo(dryRunJson);
@@ -152,12 +153,12 @@ final class CLITest {
     FileFinder finder = new CLI.DefaultFileFinder();
 
     IncludesExcludes all = IncludesExcludes.any();
-    List<Path> files = finder.findFiles(sourceDirectories, all);
+    List<Path> files = finder.findFiles(workingRepoDir, all);
     assertThat(files).containsExactly(fooJavaFile, barJavaFile);
 
     IncludesExcludes onlyFoo =
         IncludesExcludes.withSettings(workingRepoDir.toFile(), List.of("**/Foo.java"), List.of());
-    files = finder.findFiles(sourceDirectories, onlyFoo);
+    files = finder.findFiles(workingRepoDir, onlyFoo);
     assertThat(files).containsExactly(fooJavaFile);
   }
 

--- a/framework/codemodder-base/src/test/java/io/codemodder/DefaultCodemodExecutorTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/DefaultCodemodExecutorTest.java
@@ -355,7 +355,6 @@ final class DefaultCodemodExecutorTest {
             .writerWithDefaultPrettyPrinter();
     String codetf = writer.writeValueAsString(report);
     assertThat(codetf).isNotBlank();
-    System.out.println(codetf);
   }
 
   @Test


### PR DESCRIPTION
This change allows us to transform files that are not inside traditional source directories. There appears to be no downside tradeoffs, except that they will have weaker symbol resolution capabilities.