### PR TITLE
Refactored `LLMAssistedCodemod` down

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/LogFailedLoginCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/LogFailedLoginCodemod.java
@@ -1,18 +1,20 @@
 package io.codemodder.codemods;
 
+import static io.codemodder.CodemodResources.getClassResourceAsString;
+
 import com.github.difflib.patch.AbstractDelta;
 import com.github.difflib.patch.InsertDelta;
 import com.github.difflib.patch.Patch;
 import io.codemodder.Codemod;
 import io.codemodder.ReviewGuidance;
 import io.codemodder.RuleSarif;
-import io.codemodder.plugins.llm.LLMAssistedCodemod;
 import io.codemodder.plugins.llm.OpenAIService;
+import io.codemodder.plugins.llm.SarifToLLMVerifyAndFixCodemod;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import javax.inject.Inject;
 
 @Codemod(id = "pixee:java/log-failed-login", reviewGuidance = ReviewGuidance.MERGE_AFTER_REVIEW)
-public final class LogFailedLoginCodemod extends LLMAssistedCodemod {
+public final class LogFailedLoginCodemod extends SarifToLLMVerifyAndFixCodemod {
 
   @Inject
   public LogFailedLoginCodemod(
@@ -22,12 +24,12 @@ public final class LogFailedLoginCodemod extends LLMAssistedCodemod {
 
   @Override
   protected String getThreatPrompt() {
-    return getClassResourceAsString("threat_prompt.txt");
+    return getClassResourceAsString(getClass(), "threat_prompt.txt");
   }
 
   @Override
   protected String getFixPrompt() {
-    return getClassResourceAsString("fix_prompt.txt");
+    return getClassResourceAsString(getClass(), "fix_prompt.txt");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/LogFailedLoginCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/LogFailedLoginCodemod.java
@@ -9,12 +9,12 @@ import io.codemodder.Codemod;
 import io.codemodder.ReviewGuidance;
 import io.codemodder.RuleSarif;
 import io.codemodder.plugins.llm.OpenAIService;
-import io.codemodder.plugins.llm.SarifToLLMVerifyAndFixCodemod;
+import io.codemodder.plugins.llm.SarifToLLMForBinaryVerificationAndFixingCodemod;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import javax.inject.Inject;
 
 @Codemod(id = "pixee:java/log-failed-login", reviewGuidance = ReviewGuidance.MERGE_AFTER_REVIEW)
-public final class LogFailedLoginCodemod extends SarifToLLMVerifyAndFixCodemod {
+public final class LogFailedLoginCodemod extends SarifToLLMForBinaryVerificationAndFixingCodemod {
 
   @Inject
   public LogFailedLoginCodemod(

--- a/core-codemods/src/main/java/io/codemodder/codemods/SensitiveDataLoggingCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SensitiveDataLoggingCodemod.java
@@ -9,7 +9,7 @@ import io.codemodder.Codemod;
 import io.codemodder.ReviewGuidance;
 import io.codemodder.RuleSarif;
 import io.codemodder.plugins.llm.OpenAIService;
-import io.codemodder.plugins.llm.SarifToLLMVerifyAndFixCodemod;
+import io.codemodder.plugins.llm.SarifToLLMForBinaryVerificationAndFixingCodemod;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import javax.inject.Inject;
 
@@ -17,7 +17,8 @@ import javax.inject.Inject;
 @Codemod(
     id = "pixee:java/sensitive-data-logging",
     reviewGuidance = ReviewGuidance.MERGE_AFTER_REVIEW)
-public final class SensitiveDataLoggingCodemod extends SarifToLLMVerifyAndFixCodemod {
+public final class SensitiveDataLoggingCodemod
+    extends SarifToLLMForBinaryVerificationAndFixingCodemod {
 
   @Inject
   public SensitiveDataLoggingCodemod(

--- a/core-codemods/src/main/java/io/codemodder/codemods/SensitiveDataLoggingCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SensitiveDataLoggingCodemod.java
@@ -1,13 +1,15 @@
 package io.codemodder.codemods;
 
+import static io.codemodder.CodemodResources.getClassResourceAsString;
+
 import com.github.difflib.patch.AbstractDelta;
 import com.github.difflib.patch.DeleteDelta;
 import com.github.difflib.patch.Patch;
 import io.codemodder.Codemod;
 import io.codemodder.ReviewGuidance;
 import io.codemodder.RuleSarif;
-import io.codemodder.plugins.llm.LLMAssistedCodemod;
 import io.codemodder.plugins.llm.OpenAIService;
+import io.codemodder.plugins.llm.SarifToLLMVerifyAndFixCodemod;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import javax.inject.Inject;
 
@@ -15,7 +17,7 @@ import javax.inject.Inject;
 @Codemod(
     id = "pixee:java/sensitive-data-logging",
     reviewGuidance = ReviewGuidance.MERGE_AFTER_REVIEW)
-public final class SensitiveDataLoggingCodemod extends LLMAssistedCodemod {
+public final class SensitiveDataLoggingCodemod extends SarifToLLMVerifyAndFixCodemod {
 
   @Inject
   public SensitiveDataLoggingCodemod(
@@ -26,12 +28,12 @@ public final class SensitiveDataLoggingCodemod extends LLMAssistedCodemod {
 
   @Override
   protected String getThreatPrompt() {
-    return getClassResourceAsString("threat_prompt.txt");
+    return getClassResourceAsString(getClass(), "threat_prompt.txt");
   }
 
   @Override
   protected String getFixPrompt() {
-    return getClassResourceAsString("fix_prompt.txt");
+    return getClassResourceAsString(getClass(), "fix_prompt.txt");
   }
 
   @Override

--- a/framework/codemodder-base/src/main/java/io/codemodder/CodemodResources.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodemodResources.java
@@ -1,0 +1,43 @@
+package io.codemodder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.MissingResourceException;
+
+/** A utility class for accessing a codemod's resources in it's "default location" the classpath. */
+public final class CodemodResources {
+
+  private CodemodResources() {}
+
+  /**
+   * Returns a class resource as a {@code String}.
+   *
+   * <p>The absolute name of the class resource is of the following form:
+   *
+   * <blockquote>
+   *
+   * {@code /modifiedPackageName/className/relativeName}
+   *
+   * </blockquote>
+   *
+   * Where the {@code modifiedPackageName} is the package name of this object with {@code '/'}
+   * substituted for {@code '.'}.
+   *
+   * @param relativeName The relative name of the resource.
+   * @return The resource as a {@code String}.
+   * @throws MissingResourceException If the resource was not found.
+   */
+  public static String getClassResourceAsString(final Class<?> type, final String relativeName) {
+    String resourceName = "/" + type.getName().replace('.', '/') + "/" + relativeName;
+    try (InputStream stream = type.getResourceAsStream(resourceName)) {
+      if (stream == null) {
+        throw new MissingResourceException(resourceName, type.getName(), resourceName);
+      }
+      return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/FileDescription.java
+++ b/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/FileDescription.java
@@ -1,0 +1,75 @@
+package io.codemodder.plugins.llm;
+
+import io.codemodder.EncodingDetector;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Provides some methods to simplify working with the files. */
+final class FileDescription {
+
+  private final String fileName;
+  private final Charset charset;
+
+  private final String lineSeparator;
+  private final List<String> lines;
+
+  FileDescription(final Path path) {
+    fileName = path.getFileName().toString();
+
+    try {
+      charset = Charset.forName(EncodingDetector.create().detect(path).orElse("UTF-8"));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    try {
+      String s = Files.readString(path, charset);
+      lineSeparator = detectLineSeparator(s);
+      lines = List.of(s.split("\\R", -1));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  String getFileName() {
+    return fileName;
+  }
+
+  Charset getCharset() {
+    return charset;
+  }
+
+  String getLineSeparator() {
+    return lineSeparator;
+  }
+
+  List<String> getLines() {
+    return lines;
+  }
+
+  String formatLinesWithLineNumbers() {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < lines.size(); i++) {
+      sb.append(i + 1);
+      sb.append(": ");
+      sb.append(lines.get(i));
+      sb.append("\n");
+    }
+    return sb.toString();
+  }
+
+  private String detectLineSeparator(final String s) {
+    Matcher m = Pattern.compile("(\\R)").matcher(s);
+    if (m.find()) {
+      // This assumes that the first line separator found is the one to use.
+      return m.group(1);
+    }
+    return "\n";
+  }
+}

--- a/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/SarifToLLMForBinaryVerificationAndFixingCodemod.java
+++ b/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/SarifToLLMForBinaryVerificationAndFixingCodemod.java
@@ -41,12 +41,15 @@ import org.slf4j.LoggerFactory;
  *   <li>Using a more reliable (and more expensive model), confirm the finding and rewrite the code
  * </ol>
  */
-public abstract class SarifToLLMVerifyAndFixCodemod extends SarifPluginRawFileChanger {
+public abstract class SarifToLLMForBinaryVerificationAndFixingCodemod
+    extends SarifPluginRawFileChanger {
 
-  private static final Logger logger = LoggerFactory.getLogger(SarifToLLMVerifyAndFixCodemod.class);
+  private static final Logger logger =
+      LoggerFactory.getLogger(SarifToLLMForBinaryVerificationAndFixingCodemod.class);
   private final OpenAIService openAI;
 
-  protected SarifToLLMVerifyAndFixCodemod(final RuleSarif sarif, final OpenAIService openAI) {
+  protected SarifToLLMForBinaryVerificationAndFixingCodemod(
+      final RuleSarif sarif, final OpenAIService openAI) {
     super(sarif);
     this.openAI = openAI;
   }


### PR DESCRIPTION
The `LLMAssistedCodemod` was a god-class, and this is the first step towards trying to support many different types of LLM-assisted codemod architectures:

* the name was too broad, since many codemods of various shapes will be LLM-assisted
* it had a lot of inner classes will be valuable to other types, so they were extracted
* `CodemodInvocationContextFile` renamed to a package-protected `FileDescription` type