### PR TITLE
⚡️ Smaller Base Image

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,2 +1,2 @@
-FROM public.ecr.aws/amazoncorretto/amazoncorretto:17
-RUN yum install -y python3 python3-pip && python3 -m pip install semgrep
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:17-al2023-headless
+RUN dnf install -y python3 python3-pip && python3 -m pip install semgrep


### PR DESCRIPTION
Use Amazon Linux 2023 With Headless JDK Base Image.