### PR TITLE
Add `**/tests/**` to ignored

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -411,7 +411,7 @@ final class CLI implements Callable<Integer> {
           "**/web.xml");
 
   private static final List<String> defaultPathExcludes =
-      List.of("**/test/**", "**/target/**", "**/build/**", "**/.mvn/**", ".mvn/**");
+      List.of("**/test/**", "**/tests/**", "**/target/**", "**/build/**", "**/.mvn/**", ".mvn/**");
 
   private static final Logger log = LoggerFactory.getLogger(CLI.class);
 }


### PR DESCRIPTION
This came up in a PR pixeebot issued to pixeebot where a Python test resource file was cited.