### PR TITLE
Unsafe `java.io.File` path comparison

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemod.java
@@ -1,0 +1,74 @@
+package io.codemodder.codemods;
+
+import static io.codemodder.javaparser.ASTExpectations.expect;
+
+import com.contrastsecurity.sarif.Result;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import io.codemodder.*;
+import io.codemodder.providers.sarif.semgrep.SemgrepScan;
+import java.util.Optional;
+import javax.inject.Inject;
+
+/** Fix unsafe NIO path comparison. */
+@Codemod(
+    id = "pixee:java/fix-unsafe-nio-path-comparison",
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
+public final class FixUnsafeNIOPathComparisonCodemod
+    extends SarifPluginJavaParserChanger<MethodCallExpr> {
+
+  private static final String RULE =
+      """
+          rules:
+            - id: fix-unsafe-nio-path-comparison
+              patterns:
+                - pattern: (File $CHILD).getCanonicalPath().startsWith((File $PARENT).getCanonicalPath())
+          """;
+
+  @Inject
+  public FixUnsafeNIOPathComparisonCodemod(@SemgrepScan(yaml = RULE) final RuleSarif sarif) {
+    super(sarif, MethodCallExpr.class);
+  }
+
+  @Override
+  public boolean onResultFound(
+      final CodemodInvocationContext context,
+      final CompilationUnit cu,
+      final MethodCallExpr methodCallExpr,
+      final Result result) {
+
+    // make sure we have the event for the startsWith() call, not the getCanonicalPath() calls
+    if (!"startsWith".equals(methodCallExpr.getNameAsString())) {
+      return false;
+    }
+
+    // fix the child reference
+    Expression child = methodCallExpr.getScope().orElseThrow();
+    Optional<MethodCallExpr> childGetCanonicalPathCall =
+        expect(child).toBeMethodCallExpression().withName("getCanonicalPath").result();
+
+    if (childGetCanonicalPathCall.isEmpty()) {
+      return false;
+    }
+
+    Expression childScope = childGetCanonicalPathCall.get().getScope().get();
+    MethodCallExpr newChild = new MethodCallExpr(childScope, "getCanonicalFile().toPath");
+    methodCallExpr.setScope(newChild);
+
+    // fix the parent reference
+    Expression parent = methodCallExpr.getArgument(0);
+    Optional<MethodCallExpr> parentGetCanonicalPathCall =
+        expect(parent).toBeMethodCallExpression().withName("getCanonicalPath").result();
+
+    if (parentGetCanonicalPathCall.isEmpty()) {
+      return false;
+    }
+
+    Expression parentScope = parentGetCanonicalPathCall.get().getScope().get();
+    MethodCallExpr newParentArgument = new MethodCallExpr(parentScope, "getCanonicalFile().toPath");
+    methodCallExpr.setArgument(0, newParentArgument);
+
+    return true;
+  }
+}

--- a/core-codemods/src/main/resources/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemod/description.md
@@ -1,0 +1,16 @@
+This change makes path comparisons more reliable, more secure and may prevent a path traversal weakness.
+
+The current code attempts to make sure that a file is within a directory by comparing strings. This is not safe to rely on because the parent directory may not always be provided in a `File` with the trailing slash. 
+
+For instance, let's imagine we have a directory `/tmp/secure` where we want to store files. Let's now imagine we want to check if `/tmp/foo/secure-bad.txt` is in this directory. 
+
+It feels intuitively correct to try to compare the two paths using a `startsWith()` using the `File#getCanonicalPath()` from both items. However `getCanonicalPath()` will return a directory path _without_ the trailing slash, so the comparison will ask, "Does `/tmp/secure-bad.txt` start with `/tmp/secure`?". The answer would be yes, but this is not the safe and expected answer for the given paths. 
+
+Our change converts the `File` to a `Path` and uses the `Path#startsWith()` API, which understands directory structures and will return the intended answer. Here's an example of the change:
+
+```diff
+- if(child.getCanonicalPath().startsWith(parent.getCanonicalPath())) {
++ if(child.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath())) {
+    // after the change, the file is reliably in the expected directory
+  }
+```

--- a/core-codemods/src/main/resources/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemod/description.md
@@ -2,11 +2,11 @@ This change makes path comparisons more reliable, more secure and may prevent a 
 
 The current code attempts to make sure that a file is within a directory by comparing strings. This is not safe to rely on because the parent directory may not always be provided in a `File` with the trailing slash. 
 
-For instance, let's imagine we have a directory `/tmp/secure` where we want to store files. Let's now imagine we want to check if `/tmp/foo/secure-bad.txt` is in this directory. 
+For instance, let's imagine we have a directory `/tmp/secure/` where we want to store files. Let's now imagine we want to check if `/tmp/foo/secure-bad.txt` is in this directory. 
 
 It feels intuitively correct to try to compare the two paths using a `startsWith()` using the `File#getCanonicalPath()` from both items. However `getCanonicalPath()` will return a directory path _without_ the trailing slash, so the comparison will ask, "Does `/tmp/secure-bad.txt` start with `/tmp/secure`?". The answer would be yes, but this is not the safe and expected answer for the given paths. 
 
-Our change converts the `File` to a `Path` and uses the `Path#startsWith()` API, which understands directory structures and will return the intended answer. Here's an example of the change:
+Our change converts the `File` to a `Path` and uses the `Path#startsWith()` API, which natively understands directories (and isn't comparing strings), and will return the intended answer. Here's an example of the change:
 
 ```diff
 - if(child.getCanonicalPath().startsWith(parent.getCanonicalPath())) {

--- a/core-codemods/src/main/resources/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemod/report.json
@@ -1,0 +1,5 @@
+{
+  "summary" : "Fix unsafe NIO path comparison",
+  "change" : "Changed APIs to prevent string path comparison errors",
+  "references" : ["https://codeql.github.com/codeql-query-help/java/java-partial-path-traversal-from-remote/","https://cwe.mitre.org/data/definitions/22.html"]
+}

--- a/core-codemods/src/test/java/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemodTest.java
@@ -1,0 +1,10 @@
+package io.codemodder.codemods;
+
+import io.codemodder.testutils.CodemodTestMixin;
+import io.codemodder.testutils.Metadata;
+
+@Metadata(
+    codemodType = FixUnsafeNIOPathComparisonCodemod.class,
+    testResourceDir = "fix-unsafe-nio-path-comparison",
+    dependencies = {})
+final class FixUnsafeNIOPathComparisonCodemodTest implements CodemodTestMixin {}

--- a/core-codemods/src/test/resources/fix-unsafe-nio-path-comparison/Test.java.after
+++ b/core-codemods/src/test/resources/fix-unsafe-nio-path-comparison/Test.java.after
@@ -1,0 +1,27 @@
+package com.acme.testcode;
+
+import java.io.File;
+import java.nio.file.Path;
+
+final class Test {
+
+  void doThing(File child, File parent, Path somethingElse) {
+    // ruleid: fix-unsafe-nio-path-comparison
+    boolean unsafe1 = child.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath());
+
+    // ruleid: fix-unsafe-nio-path-comparison
+    if(child.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath())) {
+      // this is unsafe
+    }
+
+    // ok: fix-unsafe-nio-path-comparison
+    if(child.getCanonicalPath().startsWith(somethingElse)) {
+      // this can't be confirmed to be unsafe
+    }
+  }
+
+  File getChild() {
+    return super.getChild();
+  }
+
+}

--- a/core-codemods/src/test/resources/fix-unsafe-nio-path-comparison/Test.java.before
+++ b/core-codemods/src/test/resources/fix-unsafe-nio-path-comparison/Test.java.before
@@ -1,0 +1,27 @@
+package com.acme.testcode;
+
+import java.io.File;
+import java.nio.file.Path;
+
+final class Test {
+
+  void doThing(File child, File parent, Path somethingElse) {
+    // ruleid: fix-unsafe-nio-path-comparison
+    boolean unsafe1 = child.getCanonicalPath().startsWith(parent.getCanonicalPath());
+
+    // ruleid: fix-unsafe-nio-path-comparison
+    if(child.getCanonicalPath().startsWith(parent.getCanonicalPath())) {
+      // this is unsafe
+    }
+
+    // ok: fix-unsafe-nio-path-comparison
+    if(child.getCanonicalPath().startsWith(somethingElse)) {
+      // this can't be confirmed to be unsafe
+    }
+  }
+
+  File getChild() {
+    return super.getChild();
+  }
+
+}


### PR DESCRIPTION
This codemod solves a particular shape of path traversal issues related to how `File#getCanonicalPath()` handles directories.