### PR TITLE
Move from `String`-based charset lookup to `StandardCharsets`

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/Exceptions.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/Exceptions.java
@@ -1,0 +1,127 @@
+package io.codemodder.codemods;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.CatchClause;
+import com.github.javaparser.ast.stmt.TryStmt;
+import com.github.javaparser.ast.type.ReferenceType;
+import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * This method holds some candidate APIs for dealing with exception management, usually in light of
+ * post-processing a codemod change. After some stability is achieved here, this should be made a
+ * public API.
+ */
+final class Exceptions {
+
+  private Exceptions() {
+    // utility class
+  }
+
+  /**
+   * Attempts to remove handling of {@link java.io.UnsupportedEncodingException} in situations where
+   * we can guess it's no longer needed. This method is not guaranteed to be correct due to limited
+   * type resolution.
+   *
+   * @param node the new or modified node
+   * @param exceptionFqcn the fully qualified class name of the exception that is no longer thrown
+   *     after the change to the node
+   */
+  static void cleanupExceptionHandling(final Node node, final String exceptionFqcn) {
+    Optional<TryStmt> tryStmt = node.findAncestor(TryStmt.class);
+    String exceptionSimpleName = exceptionFqcn.substring(exceptionFqcn.lastIndexOf('.') + 1);
+    if (tryStmt.isPresent()) {
+      TryStmt tryStatement = tryStmt.get();
+      Node parent = tryStatement.getParentNode().get();
+      List<MethodCallExpr> allOtherMethodCallsInTry =
+          tryStatement.getTryBlock().findAll(MethodCallExpr.class).stream().toList();
+      List<ObjectCreationExpr> allConstructorsInTry =
+          tryStatement.getTryBlock().findAll(ObjectCreationExpr.class).stream().toList();
+      if (anyOtherMethodsAreKnownThrowThis(
+          allOtherMethodCallsInTry, allConstructorsInTry, exceptionFqcn)) {
+        // we can't touch it
+        return;
+      }
+
+      // if there's no other methods we think are causing this exception, let's remove the clause
+      NodeList<CatchClause> catchClauses = tryStatement.getCatchClauses();
+      catchClauses.removeIf(
+          cc ->
+              cc.getParameter().getType().isClassOrInterfaceType()
+                  && cc.getParameter()
+                      .getType()
+                      .asClassOrInterfaceType()
+                      .getNameAsString()
+                      .equals(exceptionSimpleName));
+
+      if (catchClauses.isEmpty()) {
+        BlockStmt tryBlockCode = tryStatement.getTryBlock();
+        parent.replace(tryStatement, tryBlockCode);
+      }
+    } else {
+      // the method signature can have the throws clause
+      Optional<MethodDeclaration> methodDeclaration = node.findAncestor(MethodDeclaration.class);
+      if (methodDeclaration.isEmpty()) {
+        return;
+      }
+      MethodDeclaration method = methodDeclaration.get();
+      List<MethodCallExpr> allOtherMethodCallsInTry =
+          method.findAll(MethodCallExpr.class).stream().toList();
+      List<ObjectCreationExpr> allConstructorsInTry =
+          method.findAll(ObjectCreationExpr.class).stream().toList();
+      if (anyOtherMethodsAreKnownThrowThis(
+          allOtherMethodCallsInTry, allConstructorsInTry, exceptionFqcn)) {
+        // we can't touch it
+        return;
+      }
+
+      NodeList<ReferenceType> thrownExceptions = method.getThrownExceptions();
+      thrownExceptions.removeIf(
+          referenceType ->
+              referenceType.asClassOrInterfaceType().getNameAsString().equals(exceptionSimpleName));
+    }
+  }
+
+  private static boolean anyOtherMethodsAreKnownThrowThis(
+      final List<MethodCallExpr> allOtherMethodCallsInTry,
+      final List<ObjectCreationExpr> allConstructorsInTry,
+      final String exceptionFqcn) {
+    // detect from the methods
+    for (MethodCallExpr method : allOtherMethodCallsInTry) {
+      try {
+        ResolvedMethodDeclaration resolve = method.resolve();
+        List<ResolvedType> methodExceptionTypes = resolve.getSpecifiedExceptions();
+        for (ResolvedType methodExceptionType : methodExceptionTypes) {
+          if (methodExceptionType.asReferenceType().getQualifiedName().equals(exceptionFqcn)) {
+            return true;
+          }
+        }
+      } catch (Exception e) {
+        // we can't resolve the method, so we can't tell if it throws this exception
+      }
+    }
+    // detect from the constructors
+    for (ObjectCreationExpr constructor : allConstructorsInTry) {
+      try {
+        ResolvedConstructorDeclaration resolve = constructor.resolve();
+        List<ResolvedType> constructorExceptionTypes = resolve.getSpecifiedExceptions();
+        for (ResolvedType constructorExceptionType : constructorExceptionTypes) {
+          if (constructorExceptionType.asReferenceType().getQualifiedName().equals(exceptionFqcn)) {
+            return true;
+          }
+        }
+      } catch (Exception e) {
+        // we can't resolve the constructor, so we can't tell if it throws this exception
+      }
+    }
+    return false;
+  }
+}

--- a/core-codemods/src/main/java/io/codemodder/codemods/SwitchToStandardCharsetsCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SwitchToStandardCharsetsCodemod.java
@@ -1,0 +1,136 @@
+package io.codemodder.codemods;
+
+import static io.codemodder.ast.ASTTransforms.addImportIfMissing;
+import static io.codemodder.javaparser.ASTExpectations.expect;
+
+import com.contrastsecurity.sarif.Result;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.*;
+import io.codemodder.*;
+import io.codemodder.providers.sarif.semgrep.SemgrepScan;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import javax.inject.Inject;
+
+/** Moves strings to {@link StandardCharsets} fields. */
+@Codemod(
+    id = "pixee:java/switch-to-standard-charsets",
+    reviewGuidance = ReviewGuidance.MERGE_AFTER_REVIEW)
+public final class SwitchToStandardCharsetsCodemod extends CompositeJavaParserChanger {
+
+  @Inject
+  public SwitchToStandardCharsetsCodemod(
+      final GetBytesCodemod getBytesCodemod, final CharsetForNameCodemod charsetForNameCodemode) {
+    super(getBytesCodemod, charsetForNameCodemode);
+  }
+
+  private static class GetBytesCodemod extends SarifPluginJavaParserChanger<MethodCallExpr> {
+    private static final String RULE =
+        """
+                rules:
+                  - id: switch-to-standard-charsets
+                    patterns:
+                      - pattern: (String $X).getBytes("...")
+                """;
+
+    @Inject
+    private GetBytesCodemod(@SemgrepScan(yaml = RULE) final RuleSarif ruleSarif) {
+      super(ruleSarif, MethodCallExpr.class, CodemodReporterStrategy.empty());
+    }
+
+    @Override
+    public boolean onResultFound(
+        final CodemodInvocationContext context,
+        final CompilationUnit cu,
+        final MethodCallExpr methodCallExpr,
+        final Result result) {
+
+      final Charset c = getSpecifiedCharset(methodCallExpr);
+      if (c == null) {
+        return false;
+      }
+
+      FieldAccessExpr field =
+          new FieldAccessExpr(
+              new NameExpr(StandardCharsets.class.getSimpleName()), getCharsetFieldName(c));
+      methodCallExpr.setArgument(0, field);
+      addImportIfMissing(cu, StandardCharsets.class);
+
+      Exceptions.cleanupExceptionHandling(
+          field.getParentNode().get(), unsupportedEncodingExceptionFqcn);
+      return true;
+    }
+  }
+
+  private static class CharsetForNameCodemod extends SarifPluginJavaParserChanger<MethodCallExpr> {
+    private static final String RULE =
+        """
+                rules:
+                  - id: switch-to-standard-charsets-in-forname
+                    patterns:
+                      - pattern: Charset.forName("...")
+                """;
+
+    @Inject
+    private CharsetForNameCodemod(@SemgrepScan(yaml = RULE) final RuleSarif ruleSarif) {
+      super(ruleSarif, MethodCallExpr.class, CodemodReporterStrategy.empty());
+    }
+
+    @Override
+    public boolean onResultFound(
+        final CodemodInvocationContext context,
+        final CompilationUnit cu,
+        final MethodCallExpr methodCallExpr,
+        final Result result) {
+
+      final Charset c = getSpecifiedCharset(methodCallExpr);
+      if (c == null) {
+        return false;
+      }
+
+      FieldAccessExpr field =
+          new FieldAccessExpr(
+              new NameExpr(StandardCharsets.class.getSimpleName()), getCharsetFieldName(c));
+      Optional<Node> parentNode = methodCallExpr.getParentNode();
+      parentNode.get().replace(methodCallExpr, field);
+      addImportIfMissing(cu, StandardCharsets.class);
+      Exceptions.cleanupExceptionHandling(parentNode.get(), unsupportedEncodingExceptionFqcn);
+      return true;
+    }
+  }
+
+  private static Charset getSpecifiedCharset(final MethodCallExpr methodCallExpr) {
+    Expression argument = methodCallExpr.getArgument(0);
+    Optional<StringLiteralExpr> charsetRef = expect(argument).toBeStringLiteral().result();
+
+    if (charsetRef.isEmpty()) {
+      return null;
+    }
+
+    StringLiteralExpr charsetExpr = charsetRef.get();
+    String charset = charsetExpr.getValue();
+
+    final Charset c;
+    switch (charset) {
+      case "US-ASCII" -> c = StandardCharsets.US_ASCII;
+      case "UTF-8" -> c = StandardCharsets.UTF_8;
+      case "UTF-16" -> c = StandardCharsets.UTF_16;
+      case "UTF-16LE" -> c = StandardCharsets.UTF_16LE;
+      case "UTF-16BE" -> c = StandardCharsets.UTF_16BE;
+      case "ISO-8859-1" -> c = StandardCharsets.ISO_8859_1;
+      default -> {
+        return null;
+      }
+    }
+    return c;
+  }
+
+  private static String getCharsetFieldName(final Charset c) {
+    return c.name().replace("-", "_");
+  }
+
+  private static final String unsupportedEncodingExceptionFqcn =
+      "java.io.UnsupportedEncodingException";
+}

--- a/core-codemods/src/main/resources/io/codemodder/codemods/SwitchToStandardCharsetsCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/SwitchToStandardCharsetsCodemod/description.md
@@ -1,0 +1,13 @@
+This change removes character set lookups with hardcoded strings like `"UTF-8"` in favor of referencing the `StandardCharsets` constants.
+
+This is faster, more predictable, and will remove the need for handling the `UnsupportedEncodingException`, which makes code easier to reason about. It will also remove compiler warnings.
+
+Our changes look something like this:
+
+```diff
+  String s = getPropertyValue();
+- byte[] b = s.getBytes("UTF-8");
++ byte[] b = s.getBytes(StandardCharsets.UTF_8);
+```
+
+Note: more changes related to exception handling may be needed.

--- a/core-codemods/src/main/resources/io/codemodder/codemods/SwitchToStandardCharsetsCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/SwitchToStandardCharsetsCodemod/description.md
@@ -1,6 +1,6 @@
-This change removes character set lookups with hardcoded strings like `"UTF-8"` in favor of referencing the `StandardCharsets` constants.
+This change removes character set lookups with hardcoded strings like `"UTF-8"` in favor of referencing the `StandardCharsets` constants, which were [introduced in Java 7](https://docs.oracle.com/javase/7/docs/api/java/nio/charset/StandardCharsets.html).
 
-This is faster, more predictable, and will remove the need for handling the `UnsupportedEncodingException`, which makes code easier to reason about. It will also remove compiler warnings.
+This is faster, more predictable, and will remove the need for handling the `UnsupportedEncodingException`, which makes code easier to reason about. It will also remove IDE and compiler warnings.
 
 Our changes look something like this:
 
@@ -10,4 +10,4 @@ Our changes look something like this:
 + byte[] b = s.getBytes(StandardCharsets.UTF_8);
 ```
 
-Note: more changes related to exception handling may be needed.
+Note: Further changes to exception handling may be needed.

--- a/core-codemods/src/main/resources/io/codemodder/codemods/SwitchToStandardCharsetsCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/SwitchToStandardCharsetsCodemod/report.json
@@ -1,0 +1,8 @@
+{
+  "summary" : "Switch to StandardCharsets fields instead of strings",
+  "change": "Switched to pointers instead of String lookups for charset retrieval",
+  "references" : [
+    "https://community.sonarsource.com/t/use-standardcharsets-instead-of-charset-names/638",
+    "https://github.com/pmd/pmd/issues/3190"
+  ]
+}

--- a/core-codemods/src/test/java/io/codemodder/codemods/SwitchToStandardCharsetsCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/SwitchToStandardCharsetsCodemodTest.java
@@ -1,0 +1,10 @@
+package io.codemodder.codemods;
+
+import io.codemodder.testutils.CodemodTestMixin;
+import io.codemodder.testutils.Metadata;
+
+@Metadata(
+    codemodType = SwitchToStandardCharsetsCodemod.class,
+    testResourceDir = "switch-to-standard-charsets",
+    dependencies = {})
+final class SwitchToStandardCharsetsCodemodTest implements CodemodTestMixin {}

--- a/core-codemods/src/test/resources/switch-to-standard-charsets/Test.java.after
+++ b/core-codemods/src/test/resources/switch-to-standard-charsets/Test.java.after
@@ -1,0 +1,47 @@
+package com.acme.testcode;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+final class Test {
+
+   void foo(String str) throws UnsupportedEncodingException {
+       str.getBytes(StandardCharsets.UTF_8);
+       str.getBytes(StandardCharsets.UTF_16);
+       str.getBytes(StandardCharsets.UTF_16LE);
+       str.getBytes(StandardCharsets.UTF_16BE);
+       str.getBytes(StandardCharsets.US_ASCII);
+       str.getBytes(StandardCharsets.ISO_8859_1);
+       str.getBytes("unknown charset");
+       str.getBytes(StandardCharsets.UTF_8);
+
+       Object o = new Object();
+       o.getBytes("UTF-8"); // this is not a string, so shouldn't act on it
+   }
+
+   void bar(String s) {
+     Charset c = StandardCharsets.UTF_8;
+     byte[] b = s.getBytes(StandardCharsets.UTF_16LE);
+     Charset.forName("unknown");
+   }
+
+   void removeTryBlock(String tryblock) {
+     {
+       new Object(); // just a random constructor
+       tryblock.getBytes(StandardCharsets.UTF_8);
+     }
+   }
+
+   void removePropagating(String removeProp) {
+     removeProp.getBytes(StandardCharsets.UTF_8);
+     new Skadoodle(); // just a random, unresolvable constructor
+   }
+
+   void cantResolve(String tryblock) {
+     {
+       tryblock.getBytes(StandardCharsets.UTF_8);
+       cantResolveThisMethod(); // probably doesn't throw UnsupportedEncodingException, so it's fine
+     }
+   }
+}

--- a/core-codemods/src/test/resources/switch-to-standard-charsets/Test.java.after
+++ b/core-codemods/src/test/resources/switch-to-standard-charsets/Test.java.after
@@ -33,6 +33,15 @@ final class Test {
      }
    }
 
+   void cantRemoveTryBlock(String tryblock) {
+     try {
+       new Object(); // just a random constructor
+       tryblock.getBytes(StandardCharsets.UTF_8);
+     } catch (IllegalArgumentException e) {
+       e.printStackTrace(System.err);
+     }
+   }
+
    void removePropagating(String removeProp) {
      removeProp.getBytes(StandardCharsets.UTF_8);
      new Skadoodle(); // just a random, unresolvable constructor

--- a/core-codemods/src/test/resources/switch-to-standard-charsets/Test.java.before
+++ b/core-codemods/src/test/resources/switch-to-standard-charsets/Test.java.before
@@ -34,6 +34,17 @@ final class Test {
      }
    }
 
+   void cantRemoveTryBlock(String tryblock) {
+     try {
+       new Object(); // just a random constructor
+       tryblock.getBytes("UTF-8");
+     } catch (UnsupportedEncodingException e) {
+       e.printStackTrace();
+     } catch (IllegalArgumentException e) {
+       e.printStackTrace(System.err);
+     }
+   }
+
    void removePropagating(String removeProp) throws UnsupportedEncodingException {
      removeProp.getBytes("UTF-8");
      new Skadoodle(); // just a random, unresolvable constructor

--- a/core-codemods/src/test/resources/switch-to-standard-charsets/Test.java.before
+++ b/core-codemods/src/test/resources/switch-to-standard-charsets/Test.java.before
@@ -1,0 +1,50 @@
+package com.acme.testcode;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+final class Test {
+
+   void foo(String str) throws UnsupportedEncodingException {
+       str.getBytes("UTF-8");
+       str.getBytes("UTF-16");
+       str.getBytes("UTF-16LE");
+       str.getBytes("UTF-16BE");
+       str.getBytes("US-ASCII");
+       str.getBytes("ISO-8859-1");
+       str.getBytes("unknown charset");
+       str.getBytes(StandardCharsets.UTF_8);
+
+       Object o = new Object();
+       o.getBytes("UTF-8"); // this is not a string, so shouldn't act on it
+   }
+
+   void bar(String s) {
+     Charset c = Charset.forName("UTF-8");
+     byte[] b = s.getBytes(Charset.forName("UTF-16LE"));
+     Charset.forName("unknown");
+   }
+
+   void removeTryBlock(String tryblock) {
+     try {
+       new Object(); // just a random constructor
+       tryblock.getBytes("UTF-8");
+     } catch (UnsupportedEncodingException e) {
+       e.printStackTrace();
+     }
+   }
+
+   void removePropagating(String removeProp) throws UnsupportedEncodingException {
+     removeProp.getBytes("UTF-8");
+     new Skadoodle(); // just a random, unresolvable constructor
+   }
+
+   void cantResolve(String tryblock) {
+     try {
+       tryblock.getBytes("UTF-8");
+       cantResolveThisMethod(); // probably doesn't throw UnsupportedEncodingException, so it's fine
+     } catch (UnsupportedEncodingException e) {
+       e.printStackTrace();
+     }
+   }
+}

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/ASTExpectations.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/ASTExpectations.java
@@ -4,6 +4,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
@@ -87,9 +88,32 @@ public final class ASTExpectations {
       return new ExpressionStatementExpectation(Optional.of((ExpressionStmt) nodeRef.get()));
     }
 
+    public StringLiteralExpectation toBeStringLiteral() {
+      if (nodeRef.isEmpty() || !(nodeRef.get() instanceof StringLiteralExpr)) {
+        return new StringLiteralExpectation(Optional.empty());
+      }
+      return new StringLiteralExpectation(Optional.of((StringLiteralExpr) nodeRef.get()));
+    }
+
     @Override
     public Optional<Node> result() {
       return nodeRef;
+    }
+  }
+
+  /** A type for querying and filtering string literals. */
+  public static class StringLiteralExpectation
+      implements ASTExpectationProducer<StringLiteralExpr> {
+
+    private final Optional<StringLiteralExpr> stringLiteralExpr;
+
+    public StringLiteralExpectation(final Optional<StringLiteralExpr> stringLiteralExpr) {
+      this.stringLiteralExpr = stringLiteralExpr;
+    }
+
+    @Override
+    public Optional<StringLiteralExpr> result() {
+      return stringLiteralExpr;
     }
   }
 


### PR DESCRIPTION
This codemod is straightforward but it's notable in that it attempts to "clean up" the exception handling of the method, which may need changes after the code change. 

Compare the `Test.java.before/after` to see the types of code changes this now supports. Happily, the type resolution provided by JavaParser means this will generally be correct a lot. I think this is safe enough to move to `DefaultCodemods` -- meaning it will be right 95% of the time, and when it's not right, it's an easy fix -- but happy to hear your opinion.