### PR TITLE
Migrate some commons-io methods to NIO

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/MigrateFilesCommonsIOToNIOCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/MigrateFilesCommonsIOToNIOCodemod.java
@@ -1,0 +1,109 @@
+package io.codemodder.codemods;
+
+import static io.codemodder.javaparser.JavaParserTransformer.replace;
+
+import com.contrastsecurity.sarif.Result;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import io.codemodder.*;
+import io.codemodder.providers.sarif.semgrep.SemgrepScan;
+import java.util.Objects;
+import javax.inject.Inject;
+
+/**
+ * Migrates {@link org.apache.commons.io.FileUtils} APIs to {@link java.nio.file.Files} where
+ * possible. Some of the contracts between FileUtils and Files are similar, but not exactly the
+ * same, so they're not good candidates for simple migration of APIs.
+ */
+@Codemod(
+    id = "pixee:java/migrate-files-commons-io-to-nio",
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
+public final class MigrateFilesCommonsIOToNIOCodemod extends CompositeJavaParserChanger {
+
+  @Inject
+  public MigrateFilesCommonsIOToNIOCodemod(
+      final ReadLinesCodemod readLinesCodemod,
+      final ReadStringCodemod readStringCodemod,
+      final ReadBytesCodemod readBytesCodemod) {
+    super(readLinesCodemod, readStringCodemod, readBytesCodemod);
+  }
+
+  private static class ReadLinesCodemod extends CommonsToNIOToPathChanger {
+    private static final String RULE =
+        """
+            rules:
+              - id: migrate-files-commons-io-to-nio-read-file-to-lines
+                pattern-either:
+                  - pattern: (org.apache.commons.io.FileUtils).readLines($X)
+                  - pattern: (org.apache.commons.io.FileUtils).readLines($X, (Charset $Y))
+            """;
+
+    @Inject
+    private ReadLinesCodemod(@SemgrepScan(yaml = RULE) final RuleSarif sarif) {
+      super(sarif, "readAllLines");
+    }
+  }
+
+  private static class ReadStringCodemod extends CommonsToNIOToPathChanger {
+    private static final String RULE =
+        """
+            rules:
+              - id: migrate-files-commons-io-to-nio-read-file-to-string
+                pattern-either:
+                  - pattern: (org.apache.commons.io.FileUtils).readFileToString($X)
+                  - pattern: (org.apache.commons.io.FileUtils).readFileToString($X, (Charset $Y))
+            """;
+
+    @Inject
+    private ReadStringCodemod(@SemgrepScan(yaml = RULE) final RuleSarif sarif) {
+      super(sarif, "readString");
+    }
+  }
+
+  private static class ReadBytesCodemod extends CommonsToNIOToPathChanger {
+    private static final String RULE =
+        """
+            rules:
+              - id: migrate-files-commons-io-to-nio-read-file-to-bytes
+                pattern: (org.apache.commons.io.FileUtils).readFileToByteArray($X)
+            """;
+
+    @Inject
+    private ReadBytesCodemod(@SemgrepScan(yaml = RULE) final RuleSarif sarif) {
+      super(sarif, "readAllBytes");
+    }
+  }
+
+  private abstract static class CommonsToNIOToPathChanger
+      extends SarifPluginJavaParserChanger<MethodCallExpr> {
+    private final String methodName;
+
+    private CommonsToNIOToPathChanger(final RuleSarif ruleSarif, final String methodName) {
+      super(ruleSarif, MethodCallExpr.class, CodemodReporterStrategy.empty());
+      this.methodName = Objects.requireNonNull(methodName);
+    }
+
+    @Override
+    public boolean onResultFound(
+        final CodemodInvocationContext context,
+        final CompilationUnit cu,
+        final MethodCallExpr readFileToStringCall,
+        final Result result) {
+      switchFirstArgumentToPath(readFileToStringCall.getArguments());
+      return replace(readFileToStringCall)
+          .withStaticMethod("java.nio.file.Files", methodName)
+          .withSameArguments();
+    }
+
+    /**
+     * Changes the first argument of the given {@link NodeList} to a {@link java.nio.file.Path}.
+     * Assumes the first argument is a {@link java.io.File}.
+     */
+    private static void switchFirstArgumentToPath(final NodeList<Expression> arguments) {
+      MethodCallExpr toPath = new MethodCallExpr(arguments.get(0), "toPath");
+      arguments.set(0, toPath);
+    }
+  }
+}

--- a/core-codemods/src/main/java/io/codemodder/codemods/MigrateFilesCommonsIOToNIOCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/MigrateFilesCommonsIOToNIOCodemod.java
@@ -1,5 +1,6 @@
 package io.codemodder.codemods;
 
+import static io.codemodder.ast.ASTTransforms.removeImportIfUnused;
 import static io.codemodder.javaparser.JavaParserTransformer.replace;
 
 import com.contrastsecurity.sarif.Result;
@@ -92,9 +93,16 @@ public final class MigrateFilesCommonsIOToNIOCodemod extends CompositeJavaParser
         final MethodCallExpr readFileToStringCall,
         final Result result) {
       switchFirstArgumentToPath(readFileToStringCall.getArguments());
-      return replace(readFileToStringCall)
-          .withStaticMethod("java.nio.file.Files", methodName)
-          .withSameArguments();
+      boolean success =
+          replace(readFileToStringCall)
+              .withStaticMethod("java.nio.file.Files", methodName)
+              .withSameArguments();
+
+      if (success) {
+        removeImportIfUnused(cu, "org.apache.commons.io.FileUtils");
+      }
+
+      return success;
     }
 
     /**

--- a/core-codemods/src/main/resources/io/codemodder/codemods/MigrateFilesCommonsIOToNIOCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/MigrateFilesCommonsIOToNIOCodemod/description.md
@@ -1,0 +1,11 @@
+This change replaces the usage of some [Apache Commons IO](https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FileUtils.html) file reading methods in favor of [Java's NIO API](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/Files.html). 
+
+Java NIO has native tools and a non-blocking strategy that make it faster for many use cases. Commons IO is often brought into a project for a handful of quality-of-life `File`-related APIs. Migrating to NIO could allow the project to remove this dependency, reducing the artifact size and shrinking the attack surface.
+
+```diff
+- import org.apache.commons.io.FileUtils; 
++ import java.nio.file.Files;
+
+- String fileContents = FileUtils.readFileToString(file);
++ String fileContents = Files.readString(file.toPath());
+```

--- a/core-codemods/src/main/resources/io/codemodder/codemods/MigrateFilesCommonsIOToNIOCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/MigrateFilesCommonsIOToNIOCodemod/report.json
@@ -1,0 +1,8 @@
+{
+  "summary" : "Migrated Apache `commons-io` APIs to Java's NIO",
+  "change" : "Migrated Apache commons-io APIs to Java's NIO",
+  "references" : [
+    "https://itsallbinary.com/reading-file-to-string-in-java-with-performance-io-nio-apache-commons-io-google-guava/",
+    "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/Files.html"
+  ]
+}

--- a/core-codemods/src/test/java/io/codemodder/codemods/MigrateFilesCommonsIOtoNIOCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/MigrateFilesCommonsIOtoNIOCodemodTest.java
@@ -1,0 +1,10 @@
+package io.codemodder.codemods;
+
+import io.codemodder.testutils.CodemodTestMixin;
+import io.codemodder.testutils.Metadata;
+
+@Metadata(
+    codemodType = MigrateFilesCommonsIOToNIOCodemod.class,
+    testResourceDir = "migrate-files-commons-io-to-nio",
+    dependencies = {})
+final class MigrateFilesCommonsIOtoNIOCodemodTest implements CodemodTestMixin {}

--- a/core-codemods/src/test/resources/migrate-files-commons-io-to-nio/CanRemoveImport.java.after
+++ b/core-codemods/src/test/resources/migrate-files-commons-io-to-nio/CanRemoveImport.java.after
@@ -1,0 +1,11 @@
+package com.acme.testcode;
+
+import java.io.File;
+import java.nio.file.Files;
+public final class Test {
+
+  void doThing(File file, Charset charset) {
+    Files.readString(file.toPath());
+  }
+
+}

--- a/core-codemods/src/test/resources/migrate-files-commons-io-to-nio/CanRemoveImport.java.before
+++ b/core-codemods/src/test/resources/migrate-files-commons-io-to-nio/CanRemoveImport.java.before
@@ -1,0 +1,12 @@
+package com.acme.testcode;
+
+import java.io.File;
+import org.apache.commons.io.FileUtils;
+
+public final class Test {
+
+  void doThing(File file, Charset charset) {
+    FileUtils.readFileToString(file);
+  }
+
+}

--- a/core-codemods/src/test/resources/migrate-files-commons-io-to-nio/Test.java.after
+++ b/core-codemods/src/test/resources/migrate-files-commons-io-to-nio/Test.java.after
@@ -1,0 +1,20 @@
+package com.acme.testcode;
+
+import java.io.File;
+import java.nio.file.Files;
+import org.apache.commons.io.FileUtils;
+
+public final class Test {
+
+  void doThing(File file, Charset charset) {
+    // ruleid: migrate-files-commons-io-to-nio-read-file-to-string
+    String s = Files.readString(file.toPath());
+
+    List<String> s2 = Files.readAllLines(file.toPath(), charset);
+    List<String> s3 = FileUtils.readLines(file, "UTF-8");// this one can't be migrated directly
+
+    // ok: migrate-files-commons-io-to-nio-read-file-to-string
+    String s = my.acme.FileUtils.readFileToString(file.toPath());
+  }
+
+}

--- a/core-codemods/src/test/resources/migrate-files-commons-io-to-nio/Test.java.before
+++ b/core-codemods/src/test/resources/migrate-files-commons-io-to-nio/Test.java.before
@@ -1,0 +1,19 @@
+package com.acme.testcode;
+
+import java.io.File;
+import org.apache.commons.io.FileUtils;
+
+public final class Test {
+
+  void doThing(File file, Charset charset) {
+    // ruleid: migrate-files-commons-io-to-nio-read-file-to-string
+    String s = FileUtils.readFileToString(file);
+
+    List<String> s2 = FileUtils.readLines(file, charset);
+    List<String> s3 = FileUtils.readLines(file, "UTF-8");// this one can't be migrated directly
+
+    // ok: migrate-files-commons-io-to-nio-read-file-to-string
+    String s = my.acme.FileUtils.readFileToString(file.toPath());
+  }
+
+}

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserTransformer.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserTransformer.java
@@ -38,7 +38,8 @@ public abstract class JavaParserTransformer {
      *
      * @param className the class name of the static method
      * @param methodName the method name
-     * @param isStaticImport whether or not the static method is imported
+     * @param isStaticImport whether the static method should be imported and referenced in an
+     *     unqualified way
      * @return true if the transformation was successful, false otherwise
      */
     boolean withStaticMethod(String className, String methodName, boolean isStaticImport);

--- a/framework/codemodder-base/src/test/java/io/codemodder/javaparser/JavaParserTransformerTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/javaparser/JavaParserTransformerTest.java
@@ -1,0 +1,145 @@
+package io.codemodder.javaparser;
+
+import static io.codemodder.ast.ASTTransforms.removeImportIfUnused;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Test aspects of {@link io.codemodder.javaparser.JavaParserTransformer}. */
+final class JavaParserTransformerTest {
+
+  private static Stream<Arguments> removeImportCases() {
+    return Stream.of(
+        Arguments.of(
+            """
+                package com.acme;
+
+                import java.io.File;
+
+                public class Foo {
+                    public void bar() {
+                        String a = File.separator;
+                    }
+                }
+                """),
+        Arguments.of(
+            """
+                package com.acme;
+
+                import java.io.File;
+
+                public class Foo {
+                    public void bar() {
+                        var a = new File("foo");
+                    }
+                }
+                """),
+        Arguments.of(
+            """
+                package com.acme;
+
+                import java.io.File;
+
+                public class Foo {
+                    public void bar() {
+                        File a = createFile("foo");
+                    }
+                }
+                """),
+        Arguments.of(
+            """
+                package com.acme;
+
+                import java.io.File;
+
+                public class Foo {
+                    public File bar() {
+                        return null;
+                    }
+                }
+                """),
+        Arguments.of(
+            """
+                package com.acme;
+
+                import java.io.File;
+
+                public class Foo {
+                    public String bar() {
+                        return File.class.getName();
+                    }
+                }
+                """),
+        Arguments.of(
+            """
+            package com.acme;
+
+            import java.io.File;
+
+            public class Foo<File> {
+                public String bar() {
+                    return "bar";
+                }
+            }
+            """),
+        Arguments.of(
+            """
+            package com.acme;
+
+            import java.io.File;
+
+            public class Foo extends File {
+                public String bar() {
+                    return "bar";
+                }
+            }
+            """));
+  }
+
+  @ParameterizedTest
+  @MethodSource("removeImportCases")
+  void it_doesnt_remove_used_imports(final String code) {
+    CompilationUnit cu = StaticJavaParser.parse(code);
+    LexicalPreservingPrinter.setup(cu);
+    removeImportIfUnused(cu, "java.io.File");
+    assertThat(LexicalPreservingPrinter.print(cu)).isEqualTo(code);
+  }
+
+  @Test
+  void it_removes_when_possible() {
+    String code =
+        """
+                package com.acme;
+
+                import java.io.File;
+
+                public class Foo {
+                    public String bar() {
+                        return "bar";
+                    }
+                }
+                """;
+
+    String afterCode =
+        """
+                package com.acme;
+
+                public class Foo {
+                    public String bar() {
+                        return "bar";
+                    }
+                }
+                """;
+    CompilationUnit cu = StaticJavaParser.parse(code);
+    LexicalPreservingPrinter.setup(cu);
+    removeImportIfUnused(cu, "java.io.File");
+    assertThat(LexicalPreservingPrinter.print(cu)).isEqualTo(afterCode);
+  }
+}


### PR DESCRIPTION
This PR is notable in that it also introduces the concept of removing an `import` if it detects there are no references to it in the code any longer. The next step would be to perform this same search over the codebase and nuke the dependency, but that feels far too ambitious to cram into this.