### PR TITLE
Add logging to match the new specification

### DIFF
--- a/framework/codemodder-base/build.gradle.kts
+++ b/framework/codemodder-base/build.gradle.kts
@@ -5,6 +5,13 @@ plugins {
 
 description = "Base framework for writing codemods in Java"
 
+// add the project version to the manifest
+tasks.jar {
+    manifest {
+        attributes["Implementation-Version"] = version
+    }
+}
+
 dependencies {
     compileOnly(libs.jetbrains.annotations)
 

--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -1,11 +1,14 @@
 package io.codemodder;
 
+import static io.codemodder.Logs.logEnteringPhase;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javaparser.JavaParser;
 import com.google.common.base.Stopwatch;
+import io.codemodder.codetf.CodeTFChangesetEntry;
 import io.codemodder.codetf.CodeTFReport;
 import io.codemodder.codetf.CodeTFReportGenerator;
 import io.codemodder.codetf.CodeTFResult;
@@ -202,6 +205,7 @@ final class CLI implements Callable<Integer> {
 
   @Override
   public Integer call() throws IOException {
+
     if (verbose) {
       LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
       context.getLogger(LoggingConfigurator.OUR_ROOT_LOGGER_NAME).setLevel(Level.DEBUG);
@@ -214,6 +218,9 @@ final class CLI implements Callable<Integer> {
       }
       return SUCCESS;
     }
+
+    logEnteringPhase(Logs.ExecutionPhase.STARTING);
+    log.info("codemodder: java/{}", CLI.class.getPackage().getImplementationVersion());
 
     if (output == null) {
       log.error("The output file is required");
@@ -237,16 +244,18 @@ final class CLI implements Callable<Integer> {
       return ERROR_CANT_READ_PROJECT_DIRECTORY;
     }
 
+    logEnteringPhase(Logs.ExecutionPhase.SETUP);
+
     if (dryRun) {
       // create a temp dir and copy all the contents into it -- this may be slow for big repos on
       // cloud i/o
       Path copiedProjectDirectory = dryRunTempDirCreationStrategy.createTempDir();
       Stopwatch watch = Stopwatch.createStarted();
-      log.info("Copying project directory for dry run..: {}", copiedProjectDirectory);
+      log.debug("dry run temporary directory: {}", copiedProjectDirectory);
       FileUtils.copyDirectory(projectDirectory, copiedProjectDirectory.toFile());
       watch.stop();
       Duration elapsed = watch.elapsed();
-      log.info("Copy took: {}", elapsed);
+      log.debug("dry run copy finished: {}ms", elapsed.toMillis());
 
       // now that we've copied it, reassign the project directory to that place
       projectDirectory = copiedProjectDirectory.toFile();
@@ -268,6 +277,9 @@ final class CLI implements Callable<Integer> {
       }
       IncludesExcludes includesExcludes =
           IncludesExcludes.withSettings(projectDirectory, pathIncludes, pathExcludes);
+
+      log.debug("including paths: {}", pathIncludes);
+      log.debug("excluding paths: {}", pathExcludes);
 
       // get all files that match
       List<SourceDirectory> sourceDirectories =
@@ -300,6 +312,8 @@ final class CLI implements Callable<Integer> {
           new CodemodLoader(codemodTypes, regulator, projectPath, pathSarifMap, codemodParameters);
       List<CodemodIdPair> codemods = loader.getCodemods();
 
+      log.debug("sarif files: {}", sarifFiles.size());
+
       // create the project providers
       List<ProjectProvider> projectProviders = loadProjectProviders();
       List<CodeTFProvider> codeTFProviders = loadCodeTFProviders();
@@ -311,6 +325,7 @@ final class CLI implements Callable<Integer> {
        * the original concrete syntax information (e.g., line numbers) in JavaParser from the first access. This
        * is what allows our codemods to act on SARIF-providing tools data accurately over multiple codemods.
        */
+      logEnteringPhase(Logs.ExecutionPhase.SCANNING);
       JavaParser javaParser = javaParserFactory.create(sourceDirectories);
       CachingJavaParser cachingJavaParser = CachingJavaParser.from(javaParser);
       for (CodemodIdPair codemod : codemods) {
@@ -323,14 +338,39 @@ final class CLI implements Callable<Integer> {
                 codeTFProviders,
                 cachingJavaParser,
                 encodingDetector);
+        log.info("running codemod: {}", codemod.getId());
         CodeTFResult result = codemodExecutor.execute(filePaths);
         if (!result.getChangeset().isEmpty() || !result.getFailedFiles().isEmpty()) {
           results.add(result);
+        }
+        if (!result.getChangeset().isEmpty()) {
+          log.info("changed:");
+          result
+              .getChangeset()
+              .forEach(
+                  entry -> {
+                    log.info("  - " + entry.getPath());
+                    String indentedDiff =
+                        entry
+                            .getDiff()
+                            .lines()
+                            .map(line -> "      " + line)
+                            .collect(Collectors.joining(System.lineSeparator()));
+                    log.debug("    diff:");
+                    log.debug(indentedDiff);
+                  });
+        }
+        if (!result.getFailedFiles().isEmpty()) {
+          log.info("failed:");
+          result.getFailedFiles().forEach(f -> log.info("  - {}", f));
         }
       }
 
       Instant end = clock.instant();
       long elapsed = end.toEpochMilli() - start.toEpochMilli();
+
+      logEnteringPhase(Logs.ExecutionPhase.REPORT);
+      logMetrics(results);
 
       // write out the output
       if (OutputFormat.CODETF.equals(outputFormat)) {
@@ -346,9 +386,12 @@ final class CLI implements Callable<Integer> {
         ObjectMapper mapper = new ObjectMapper();
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         Files.writeString(outputPath, mapper.writeValueAsString(report));
+        log.debug("report file: {}", outputPath);
       } else if (OutputFormat.DIFF.equals(outputFormat)) {
         throw new UnsupportedOperationException("not supported yet");
       }
+
+      log.debug("elapsed: {}ms", elapsed);
 
       // this is a special exit code that tells the caller to not exit
       if (dontExit) {
@@ -359,10 +402,26 @@ final class CLI implements Callable<Integer> {
     } finally {
       if (dryRun) {
         // delete the temp directory
-        log.debug("Cleaning temp directory: {}", projectDirectory);
         FileUtils.deleteDirectory(projectDirectory);
+        log.debug("cleaned temp directory: {}", projectDirectory);
       }
     }
+  }
+
+  private static void logMetrics(final List<CodeTFResult> results) {
+    List<String> failedFiles = results.stream().flatMap(r -> r.getFailedFiles().stream()).toList();
+
+    List<String> changedFiles =
+        results.stream()
+            .flatMap(r -> r.getChangeset().stream())
+            .map(CodeTFChangesetEntry::getPath)
+            .toList();
+
+    long uniqueChangedFiles = changedFiles.stream().distinct().count();
+    long uniqueFailedFiles = failedFiles.stream().distinct().count();
+
+    log.debug("failed files: {} ({} unique)", failedFiles.size(), uniqueFailedFiles);
+    log.debug("changed files: {} ({} unique)", changedFiles.size(), uniqueChangedFiles);
   }
 
   private List<CodeTFProvider> loadCodeTFProviders() {

--- a/framework/codemodder-base/src/main/java/io/codemodder/Logs.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/Logs.java
@@ -1,0 +1,28 @@
+package io.codemodder;
+
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A utility for helping meet the logging specification. */
+final class Logs {
+
+  private Logs() {}
+
+  /** Describes the phase of execution we're in. These values are set by the spec. */
+  enum ExecutionPhase {
+    STARTING,
+    SETUP,
+    SCANNING,
+    REPORT
+  }
+
+  /** Logs the start of a codemod phase. */
+  static void logEnteringPhase(final ExecutionPhase phase) {
+    Objects.requireNonNull(phase);
+    log.debug("");
+    log.debug("[{}]", phase.name().toLowerCase());
+  }
+
+  private static final Logger log = LoggerFactory.getLogger(Logs.class);
+}

--- a/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdModule.java
+++ b/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdModule.java
@@ -77,7 +77,7 @@ public final class PmdModule extends AbstractModule {
               toBind.add(rulePair);
             });
 
-        LOG.debug("Finished scanning codemod package: {}", packageName);
+        LOG.trace("Finished scanning codemod package: {}", packageName);
         packagesScanned.add(packageName);
       }
     }

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/DefaultSemgrepRunner.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/DefaultSemgrepRunner.java
@@ -24,7 +24,7 @@ final class DefaultSemgrepRunner implements SemgrepRunner {
     Path repositoryPath = repository.toAbsolutePath();
     Path sarifFile = Files.createTempFile("semgrep", ".sarif");
 
-    LOG.debug("Repository: {}", dumpInfo(repositoryPath));
+    LOG.trace("Repository: {}", dumpInfo(repositoryPath));
     List<String> args = new ArrayList<>();
     args.add("semgrep");
     args.add("--no-error");
@@ -39,7 +39,7 @@ final class DefaultSemgrepRunner implements SemgrepRunner {
     }
     args.add(repositoryPath.toString());
 
-    LOG.debug("Process arguments: {}", args);
+    LOG.trace("Process arguments: {}", args);
     /*
      * Create an empty directory to be the working directory, and add an .semgrepignore file that allows scanning
      * everything. If we don't do this, Semgrep will use its defaults which exclude a lot of stuff we want to scan.
@@ -48,18 +48,18 @@ final class DefaultSemgrepRunner implements SemgrepRunner {
     Path semgrepIgnoreFile = Files.createFile(tmpDir.resolve(".semgrepignore"));
     Files.writeString(semgrepIgnoreFile, OUR_SEMGREPIGNORE_CONTENTS);
 
-    LOG.debug("Will execute Semgrep from this directory: {}", dumpInfo(tmpDir));
-    LOG.debug("Semgrep ignore file is located at: {}", dumpInfo(semgrepIgnoreFile));
-    LOG.debug("SARIF file will be located at: {}", dumpInfo(sarifFile));
+    LOG.trace("Will execute Semgrep from this directory: {}", dumpInfo(tmpDir));
+    LOG.trace("Semgrep ignore file is located at: {}", dumpInfo(semgrepIgnoreFile));
+    LOG.trace("SARIF file will be located at: {}", dumpInfo(sarifFile));
 
     Path semgrepHome = Files.createTempDirectory("semgrep-home").toAbsolutePath();
-    LOG.debug("Semgrep home will be: {}", dumpInfo(semgrepHome));
+    LOG.trace("Semgrep home will be: {}", dumpInfo(semgrepHome));
     ProcessBuilder pb = new ProcessBuilder(args);
     pb.environment().put("HOME", semgrepHome.toString());
     Process p = pb.directory(tmpDir.toFile()).start();
     try {
       int rc = p.waitFor();
-      LOG.debug("Semgrep return code: {}", rc);
+      LOG.trace("Semgrep return code: {}", rc);
       if (rc != 0) {
         throw new RuntimeException("error code seen from semgrep execution: " + rc);
       }
@@ -69,7 +69,7 @@ final class DefaultSemgrepRunner implements SemgrepRunner {
 
     SarifSchema210 sarif =
         objectMapper.readValue(Files.newInputStream(sarifFile), SarifSchema210.class);
-    LOG.debug("SARIF results: {}", sarif.getRuns().get(0).getResults().size());
+    LOG.trace("SARIF results: {}", sarif.getRuns().get(0).getResults().size());
     Files.delete(semgrepIgnoreFile);
     Files.delete(tmpDir);
     Files.delete(sarifFile);

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepModule.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepModule.java
@@ -177,7 +177,7 @@ public final class SemgrepModule extends AbstractModule {
               toBind.add(rulePair);
             });
 
-        LOG.debug("Finished scanning codemod package: {}", packageName);
+        LOG.trace("Finished scanning codemod package: {}", packageName);
         packagesScanned.add(packageName);
       }
     }


### PR DESCRIPTION
This change creates log messages that match the `human` output format. Future changes add structured logging.

Here is a snippet with `--verbose`:

```
[starting]
codemodder: java/0.67.9-SNAPSHOT

[setup]
dry run temporary directory: /var/folders/3n/_gqxkk5j6bd07m75_2s100wm0000gn/T/codemodder-project5284919612261045500
dry run copy finished: 1024ms
including paths: [**.java, **/*.java, pom.xml, **/pom.xml, **.jsp, **/*.jsp, web.xml, **/web.xml]
excluding paths: [**/test/**, **/intTest/**, **/tests/**, **/target/**, **/build/**, **/.mvn/**, .mvn/**]
sarif files: 0

[scanning]
running codemod: pixee:java/add-clarifying-braces
running codemod: pixee:java/disable-dircontext-deserialization
running codemod: pixee:java/harden-java-deserialization
changed:
  - src/main/java/org/owasp/webgoat/lessons/xxe/Ping.java
    diff:
      --- Ping.java
      +++ Ping.java
      @@ -29,6 +29,7 @@
       import org.owasp.webgoat.container.session.WebSession;
       import org.springframework.beans.factory.annotation.Autowired;
       import org.springframework.beans.factory.annotation.Value;
      +import org.springframework.web.bind.annotation.GetMapping;
       import org.springframework.web.bind.annotation.RequestHeader;
       import org.springframework.web.bind.annotation.RequestMapping;
       import org.springframework.web.bind.annotation.RequestMethod;
      @@ -43,7 +44,7 @@
       
         @Autowired private WebSession webSession;
       
      -  @RequestMapping(method = RequestMethod.GET)
      +  @GetMapping
         @ResponseBody
         public String logRequest(
             @RequestHeader("User-Agent") String userAgent, @RequestParam(required = false) String text) {
running codemod: pixee:java/fix-verb-tampering

...

[report]
failed files: 0 (0 unique)
changed files: 46 (41 unique)
report file: /tmp/wg.codetf
elapsed: 14366ms
cleaned temp directory: /var/folders/3n/_gqxkk5j6bd07m75_2s100wm0000gn/T/
```

And the entirety of a WebGoat run with 50+ changes without `--verbose`:
```
codemodder: java/0.67.9-SNAPSHOT
running codemod: pixee:java/add-clarifying-braces
running codemod: pixee:java/disable-dircontext-deserialization
running codemod: pixee:java/harden-java-deserialization
changed:
  - src/main/java/org/owasp/webgoat/lessons/deserialization/InsecureDeserializationTask.java
  - pom.xml
  - src/main/java/org/owasp/webgoat/lessons/deserialization/SerializationHelper.java
running codemod: pixee:java/harden-process-creation
changed:
  - src/main/java/org/dummy/insecure/framework/VulnerableTaskHolder.java
running codemod: pixee:java/harden-xmldecoder-stream
running codemod: pixee:java/harden-xmlinputfactory
changed:
  - src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
running codemod: pixee:java/harden-xstream
changed:
  - src/main/java/org/owasp/webgoat/lessons/vulnerablecomponents/VulnerableComponentsLesson.java
  - pom.xml
running codemod: pixee:java/harden-zip-entry-paths
running codemod: pixee:java/hql-parameterizer
running codemod: codeql:java/input-resource-leak
running codemod: codeql:java/insecure-cookie
running codemod: codeql:java/database-resource-leak
running codemod: codeql:java/jexl-expression-injection
running codemod: pixee:java/encode-jsp-scriptlet
running codemod: pixee:java/limit-readline
changed:
  - src/main/java/org/dummy/insecure/framework/VulnerableTaskHolder.java
running codemod: codeql:java/maven/non-https-url
running codemod: codeql:java/output-resource-leak
running codemod: pixee:java/prevent-filewriter-leak-with-nio
running codemod: pixee:java/make-prng-seed-unpredictable
running codemod: pixee:java/replace-apache-defaulthttpclient
running codemod: pixee:java/sanitize-apache-multipart-filename
running codemod: pixee:java/strip-http-header-newlines
running codemod: pixee:java/sanitize-spring-multipart-filename
changed:
  - src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileUploadRemoveUserInput.java
  - src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileZipSlip.java
  - src/main/java/org/owasp/webgoat/webwolf/FileServer.java
running codemod: pixee:java/secure-random
changed:
  - src/main/java/org/owasp/webgoat/lessons/challenges/challenge1/ImageServlet.java
  - src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/PasswordResetLink.java
  - src/main/java/org/owasp/webgoat/lessons/cryptography/EncodingAssignment.java
  - src/main/java/org/owasp/webgoat/lessons/cryptography/HashingAssignment.java
  - src/main/java/org/owasp/webgoat/lessons/csrf/CSRFGetFlag.java
  - src/main/java/org/owasp/webgoat/lessons/hijacksession/cas/HijackSessionAuthenticationProvider.java
  - src/main/java/org/owasp/webgoat/lessons/jwt/JWTSecretKeyEndpoint.java
running codemod: pixee:java/sql-parameterizer
changed:
  - src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionChallenge.java
  - src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson8.java
running codemod: pixee:java/sandbox-url-creation
changed:
  - src/main/java/org/owasp/webgoat/lessons/jwt/claimmisuse/JWTHeaderJKUEndpoint.java
  - src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
running codemod: codeql:java/stack-trace-exposure
running codemod: pixee:java/switch-literal-first
changed:
  - src/it/java/org/owasp/webgoat/LabelAndHintIntegrationTest.java
  - src/main/java/org/owasp/webgoat/container/AsciiDoctorTemplateResolver.java
  - src/main/java/org/owasp/webgoat/container/lessons/Assignment.java
  - src/main/java/org/owasp/webgoat/lessons/bypassrestrictions/BypassRestrictionsFieldRestrictions.java
  - src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/Assignment7.java
  - src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/PasswordResetLink.java
  - src/main/java/org/owasp/webgoat/lessons/cryptography/SecureDefaultsAssignment.java
  - src/main/java/org/owasp/webgoat/lessons/cryptography/XOREncodingAssignment.java
  - src/main/java/org/owasp/webgoat/lessons/csrf/CSRFGetFlag.java
  - src/main/java/org/owasp/webgoat/lessons/csrf/ForgedReviews.java
  - src/main/java/org/owasp/webgoat/lessons/idor/IDORDiffAttributes.java
  - src/main/java/org/owasp/webgoat/lessons/idor/IDOREditOtherProfile.java
  - src/main/java/org/owasp/webgoat/lessons/idor/IDORViewOtherProfile.java
  - src/main/java/org/owasp/webgoat/lessons/idor/IDORViewOwnProfileAltUrl.java
  - src/main/java/org/owasp/webgoat/lessons/idor/UserProfile.java
  - src/main/java/org/owasp/webgoat/lessons/logging/LogBleedingTask.java
  - src/main/java/org/owasp/webgoat/lessons/missingac/MissingFunctionACHiddenMenus.java
  - src/main/java/org/owasp/webgoat/lessons/passwordreset/ResetLinkAssignment.java
  - src/main/java/org/owasp/webgoat/lessons/spoofcookie/SpoofCookieAssignment.java
  - src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson2.java
  - src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java
  - src/main/java/org/owasp/webgoat/lessons/xss/CrossSiteScriptingLesson3.java
running codemod: codeql:java/missing-jwt-signature-check
running codemod: pixee:java/upgrade-sslcontext-tls
running codemod: pixee:java/upgrade-sslengine-tls
running codemod: pixee:java/upgrade-sslparameters-tls
running codemod: pixee:java/upgrade-sslsocket-tls
running codemod: pixee:java/upgrade-tempfile-to-nio
running codemod: pixee:java/validate-jakarta-forward-path
running codemod: pixee:java/verbose-request-mapping
changed:
  - src/main/java/org/owasp/webgoat/lessons/csrf/CSRFGetFlag.java
  - src/main/java/org/owasp/webgoat/lessons/xxe/Ping.java
running codemod: pixee:java/fix-verb-tampering
```