### PR TITLE
Add structured logging

### DIFF
--- a/framework/codemodder-base/build.gradle.kts
+++ b/framework/codemodder-base/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 
     implementation(libs.tuples)
     implementation(libs.logback.classic)
+    implementation(libs.logstash.logback.encoder)
     implementation(libs.maven.model)
     implementation(libs.picocli)
     implementation(libs.juniversalchardet)

--- a/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
@@ -5,6 +5,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.FileAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -75,29 +79,32 @@ final class CLITest {
   }
 
   @Test
-  void it_does_structured_logging() throws IOException {
-    Path codetf = Files.createTempFile("normal", ".codetf");
-    String[] args =
-        new String[] {
-          "--dont-exit",
-          "--verbose",
-          "--log-format=json",
-          "--output",
-          codetf.toString(),
-          workingRepoDir.toString()
-        };
+  void structured_appender_works_with_project_name() throws IOException {
+    Path outputFile = Files.createTempFile("codemodder", ".out");
+    writeLogMessageToFile(outputFile, "cloud9");
+    String output = Files.readString(outputFile);
+    assertThat(output).contains("\"project_name\":\"cloud9\"");
+  }
 
-    final var stdoutWriter = new StringWriter();
-    final var stderrWriter = new StringWriter();
-    try (var stdout = new PrintWriter(stdoutWriter);
-        var stderr = new PrintWriter(stderrWriter)) {
-      Runner.run(List.of(Cloud9Changer.class), args, stdout, stderr);
-      // confirm change happened
-      assertThat(Files.readString(fooJavaFile)).contains("cloud9");
-    }
-    // confirm JSON was captured
-    String output = stdoutWriter.toString();
-    assertThat(output).contains("{ }");
+  @Test
+  void structured_appender_works_without_project_name() throws IOException {
+    Path outputFile = Files.createTempFile("codemodder", ".out");
+    writeLogMessageToFile(outputFile, null);
+    String output = Files.readString(outputFile);
+    assertThat(output).doesNotContain("cloud9");
+  }
+
+  private static void writeLogMessageToFile(final Path outputFile, final String projectName) {
+    LoggerContext context = new LoggerContext();
+    FileAppender<ILoggingEvent> appender = new FileAppender<>();
+    appender.setContext(context);
+
+    appender.setFile(outputFile.toAbsolutePath().toString());
+    appender.setImmediateFlush(true);
+    CLI.configureAppender(appender, Optional.ofNullable(projectName));
+    Logger log = context.getLogger("myRootLogger");
+    log.addAppender(appender);
+    log.info("this is a test");
   }
 
   @Test

--- a/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
@@ -75,8 +75,33 @@ final class CLITest {
   }
 
   @Test
-  void dry_run_works() throws IOException {
+  void it_does_structured_logging() throws IOException {
+    Path codetf = Files.createTempFile("normal", ".codetf");
+    String[] args =
+        new String[] {
+          "--dont-exit",
+          "--verbose",
+          "--log-format=json",
+          "--output",
+          codetf.toString(),
+          workingRepoDir.toString()
+        };
 
+    final var stdoutWriter = new StringWriter();
+    final var stderrWriter = new StringWriter();
+    try (var stdout = new PrintWriter(stdoutWriter);
+        var stderr = new PrintWriter(stderrWriter)) {
+      Runner.run(List.of(Cloud9Changer.class), args, stdout, stderr);
+      // confirm change happened
+      assertThat(Files.readString(fooJavaFile)).contains("cloud9");
+    }
+    // confirm JSON was captured
+    String output = stdoutWriter.toString();
+    assertThat(output).contains("{ }");
+  }
+
+  @Test
+  void dry_run_works() throws IOException {
     Path normalCodetf = Files.createTempFile("normal", ".codetf");
     Path dryRunCodetf = Files.createTempFile("dryrun", ".codetf");
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ jfiglet = "com.github.lalyos:jfiglet:0.0.8"
 jtokkit = { module = "com.knuddels:jtokkit", version.ref="jtokkit" }
 juniversalchardet = "com.github.albfernandez:juniversalchardet:2.4.0"
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+logstash-logback-encoder = "net.logstash.logback:logstash-logback-encoder:7.4"
 maven-model = { module = "org.apache.maven:maven-model", version.ref = "maven" }
 openai-service = { module = "com.theokanning.openai-gpt3-java:service", version.ref = "openai" }
 picocli = { module = "info.picocli:picocli", version.ref = "picocli" }


### PR DESCRIPTION
Here's a snapshot of output. I do include a framework-specific `timestamp` field that I think we'll want to add eventually.

```
$ ./gradlew :core-codemods:run --args='--output /tmp/dvja.codetf --verbose --dry-run --project-name WebGoat --log-rmat json /tmp/dvja'

{"timestamp":"2023-10-10T12:46:10.113002-04:00","message":"","level":"DEBUG","project_name":"WebGoat","file":"Logs.java","line":23}
{"timestamp":"2023-10-10T12:46:10.121251-04:00","message":"[starting]","level":"DEBUG","project_name":"WebGoat","file":"Logs.java","line":24}
{"timestamp":"2023-10-10T12:46:10.122303-04:00","message":"codemodder: java/0.67.9-SNAPSHOT","level":"INFO","project_name":"WebGoat","file":"CLI.java","line":253}
{"timestamp":"2023-10-10T12:46:10.124168-04:00","message":"","level":"DEBUG","project_name":"WebGoat","file":"Logs.java","line":23}
{"timestamp":"2023-10-10T12:46:10.1243-04:00","message":"[setup]","level":"DEBUG","project_name":"WebGoat","file":"Logs.java","line":24}
{"timestamp":"2023-10-10T12:46:10.138269-04:00","message":"dry run temporary directory: /var/folders/3n/_gqxkk5j6bd07m75_2s100wm0000gn/T/codemodder-project3203299650741969179","level":"DEBUG","project_name":"WebGoat","file":"CLI.java","line":284}
{"timestamp":"2023-10-10T12:46:10.342354-04:00","message":"dry run copy finished: 204ms","level":"DEBUG","project_name":"WebGoat","file":"CLI.java","line":288}
```

... and again without `project_name`:

```
{"timestamp":"2023-10-10T12:49:22.432909-04:00","message":"","level":"DEBUG","file":"Logs.java","line":23}
{"timestamp":"2023-10-10T12:49:22.444855-04:00","message":"[starting]","level":"DEBUG","file":"Logs.java","line":24}
{"timestamp":"2023-10-10T12:49:22.447171-04:00","message":"codemodder: java/0.67.9-SNAPSHOT","level":"INFO","file":"CLI.java","line":250}
{"timestamp":"2023-10-10T12:49:22.448285-04:00","message":"","level":"DEBUG","file":"Logs.java","line":23}
{"timestamp":"2023-10-10T12:49:22.448625-04:00","message":"[setup]","level":"DEBUG","file":"Logs.java","line":24}
```