### PR TITLE
Add a file contents cache

### DIFF
--- a/core-codemods/src/test/java/io/codemodder/codemods/AddMissingI18nCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/AddMissingI18nCodemodTest.java
@@ -232,6 +232,7 @@ final class AddMissingI18nCodemodTest {
             pair,
             List.of(),
             List.of(),
+            FileCache.createDefault(),
             CachingJavaParser.from(new JavaParser()),
             EncodingDetector.create());
     return executor.execute(

--- a/core-codemods/src/test/java/io/codemodder/codemods/JSPScriptletXSSCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/JSPScriptletXSSCodemodTest.java
@@ -47,6 +47,7 @@ final class JSPScriptletXSSCodemodTest {
             codemod,
             List.of(),
             List.of(),
+            FileCache.createDefault(),
             CachingJavaParser.from(new JavaParser()),
             EncodingDetector.create());
     CodeTFResult result = executor.execute(List.of(jsp));

--- a/core-codemods/src/test/java/io/codemodder/codemods/VerbTamperingCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/VerbTamperingCodemodTest.java
@@ -55,6 +55,7 @@ final class VerbTamperingCodemodTest {
             loader.getCodemods().get(0),
             List.of(),
             List.of(),
+            FileCache.createDefault(),
             CachingJavaParser.from(new JavaParser()),
             EncodingDetector.create());
     CodeTFResult result = executor.execute(List.of(webxml));

--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -355,7 +355,7 @@ final class CLI implements Callable<Integer> {
       logEnteringPhase(Logs.ExecutionPhase.SCANNING);
       JavaParser javaParser = javaParserFactory.create(sourceDirectories);
       CachingJavaParser cachingJavaParser = CachingJavaParser.from(javaParser);
-      FileCache fileCache = FileCache.createDefault();
+      FileCache fileCache = FileCache.createDefault(10_000);
       for (CodemodIdPair codemod : codemods) {
         CodemodExecutor codemodExecutor =
             new DefaultCodemodExecutor(

--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -355,6 +355,7 @@ final class CLI implements Callable<Integer> {
       logEnteringPhase(Logs.ExecutionPhase.SCANNING);
       JavaParser javaParser = javaParserFactory.create(sourceDirectories);
       CachingJavaParser cachingJavaParser = CachingJavaParser.from(javaParser);
+      FileCache fileCache = FileCache.createDefault();
       for (CodemodIdPair codemod : codemods) {
         CodemodExecutor codemodExecutor =
             new DefaultCodemodExecutor(
@@ -363,6 +364,7 @@ final class CLI implements Callable<Integer> {
                 codemod,
                 projectProviders,
                 codeTFProviders,
+                fileCache,
                 cachingJavaParser,
                 encodingDetector);
         log.info("running codemod: {}", codemod.getId());

--- a/framework/codemodder-base/src/main/java/io/codemodder/CodemodExecutor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodemodExecutor.java
@@ -17,6 +17,7 @@ public interface CodemodExecutor {
       final CodemodIdPair codemod,
       final List<ProjectProvider> projectProviders,
       final List<CodeTFProvider> codetfProviders,
+      final FileCache fileCache,
       final CachingJavaParser javaParser,
       final EncodingDetector encodingDetector) {
     return new DefaultCodemodExecutor(
@@ -25,6 +26,7 @@ public interface CodemodExecutor {
         codemod,
         projectProviders,
         codetfProviders,
+        fileCache,
         javaParser,
         encodingDetector);
   }

--- a/framework/codemodder-base/src/main/java/io/codemodder/CodemodInvocationContext.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodemodInvocationContext.java
@@ -21,6 +21,9 @@ public interface CodemodInvocationContext {
   /** The ID of the codemod changing the file. */
   String codemodId();
 
+  /** The original contents of the file before this codemod */
+  String contents();
+
   /**
    * Convenience method for stream-wise processing lines of the file being changed with line
    * numbers.

--- a/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
@@ -78,7 +78,6 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
         filePaths.stream().filter(codemodRunner::supports).sorted().toList();
 
     for (Path filePath : codemodTargetFiles) {
-
       // create the context necessary for the codemod to run
       LineIncludesExcludes lineIncludesExcludes =
           includesExcludes.getIncludesExcludesForFile(filePath.toFile());
@@ -137,7 +136,7 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
           changeset.add(
               new CodeTFChangesetEntry(getRelativePath(projectDir, filePath), diff, changes));
           changeset.addAll(dependencyChangesetEntries);
-          fileCache.put(filePath, afterContents);
+          fileCache.overrideEntry(filePath, afterContents);
         }
       } catch (Exception e) {
         unscannableFiles.add(filePath);

--- a/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
@@ -28,6 +28,7 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
   private final Path projectDir;
   private final IncludesExcludes includesExcludes;
   private final EncodingDetector encodingDetector;
+  private final FileCache fileCache;
 
   DefaultCodemodExecutor(
       final Path projectDir,
@@ -35,6 +36,7 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
       final CodemodIdPair codemod,
       final List<ProjectProvider> projectProviders,
       final List<CodeTFProvider> codetfProviders,
+      final FileCache fileCache,
       final CachingJavaParser cachingJavaParser,
       final EncodingDetector encodingDetector) {
     this.projectDir = Objects.requireNonNull(projectDir);
@@ -43,6 +45,7 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
     this.codetfProviders = Objects.requireNonNull(codetfProviders);
     this.projectProviders = Objects.requireNonNull(projectProviders);
     this.cachingJavaParser = Objects.requireNonNull(cachingJavaParser);
+    this.fileCache = Objects.requireNonNull(fileCache);
     this.encodingDetector = Objects.requireNonNull(encodingDetector);
   }
 
@@ -75,15 +78,16 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
         filePaths.stream().filter(codemodRunner::supports).sorted().toList();
 
     for (Path filePath : codemodTargetFiles) {
+
       // create the context necessary for the codemod to run
       LineIncludesExcludes lineIncludesExcludes =
           includesExcludes.getIncludesExcludesForFile(filePath.toFile());
-      CodemodInvocationContext context =
-          new DefaultCodemodInvocationContext(
-              codeDirectory, filePath, codemod.getId(), lineIncludesExcludes);
+
       try {
-        // capture the "before" for the diff, if needed
-        List<String> beforeFile = Files.readAllLines(filePath);
+        String fileContents = fileCache.get(filePath);
+        CodemodInvocationContext context =
+            new DefaultCodemodInvocationContext(
+                codeDirectory, filePath, fileContents, codemod.getId(), lineIncludesExcludes);
 
         // run the codemod on the file
         List<CodemodChange> codemodChanges = codemodRunner.run(context);
@@ -118,6 +122,7 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
 
           // make sure we add the file's entry first, then the dependency entries, so the causality
           // is clear
+          List<String> beforeFile = fileContents.lines().toList();
           List<String> afterFile = Files.readAllLines(filePath);
           List<String> patchDiff =
               UnifiedDiffUtils.generateUnifiedDiff(

--- a/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
@@ -123,7 +123,8 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
           // make sure we add the file's entry first, then the dependency entries, so the causality
           // is clear
           List<String> beforeFile = fileContents.lines().toList();
-          List<String> afterFile = Files.readAllLines(filePath);
+          String afterContents = Files.readString(filePath);
+          List<String> afterFile = afterContents.lines().toList();
           List<String> patchDiff =
               UnifiedDiffUtils.generateUnifiedDiff(
                   filePath.getFileName().toString(),
@@ -136,6 +137,7 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
           changeset.add(
               new CodeTFChangesetEntry(getRelativePath(projectDir, filePath), diff, changes));
           changeset.addAll(dependencyChangesetEntries);
+          fileCache.put(filePath, afterContents);
         }
       } catch (Exception e) {
         unscannableFiles.add(filePath);

--- a/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodInvocationContext.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodInvocationContext.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 record DefaultCodemodInvocationContext(
     CodeDirectory codeDirectory,
     Path path,
+    String contents,
     String codemodId,
     LineIncludesExcludes lineIncludesExcludes)
     implements CodemodInvocationContext {
@@ -13,6 +14,7 @@ record DefaultCodemodInvocationContext(
   DefaultCodemodInvocationContext {
     Objects.requireNonNull(codeDirectory);
     Objects.requireNonNull(path);
+    Objects.requireNonNull(contents);
     Objects.requireNonNull(codemodId);
     Objects.requireNonNull(lineIncludesExcludes);
   }

--- a/framework/codemodder-base/src/main/java/io/codemodder/FileCache.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/FileCache.java
@@ -1,0 +1,42 @@
+package io.codemodder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A cache for file contents. This is useful for caching file contents when running codemods that
+ */
+public interface FileCache {
+
+  /** Get the string contents of a file. */
+  String get(Path path) throws IOException;
+
+  /** Put the string contents of a file into the cache. */
+  void put(Path path, String contents);
+
+  static FileCache createDefault() {
+    return new FileCache() {
+      private final Map<Path, String> fileCache = new ConcurrentHashMap<>();
+
+      @Override
+      public String get(final Path path) throws IOException {
+        String contents = fileCache.get(path);
+        if (contents == null) {
+          contents = Files.readString(path);
+          if (fileCache.size() < 5000) {
+            fileCache.put(path, contents);
+          }
+        }
+        return contents;
+      }
+
+      @Override
+      public void put(final Path path, final String contents) {
+        fileCache.put(path, contents);
+      }
+    };
+  }
+}

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/CachingJavaParser.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/CachingJavaParser.java
@@ -17,10 +17,11 @@ public interface CachingJavaParser {
    * CompilationUnit}.
    *
    * @param file a Java file path
+   * @param contents the contents of the file
    * @return a {@link CompilationUnit} for the given file
    * @throws IOException if there is a file I/O error
    */
-  CompilationUnit parseJavaFile(Path file) throws IOException;
+  CompilationUnit parseJavaFile(Path file, String contents);
 
   /** Return a simple implementation of the {@link CachingJavaParser} interface. */
   static CachingJavaParser from(final JavaParser parser) {

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/DefaultCachingJavaParser.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/DefaultCachingJavaParser.java
@@ -4,9 +4,6 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,19 +20,17 @@ final class DefaultCachingJavaParser implements CachingJavaParser {
   }
 
   @Override
-  public CompilationUnit parseJavaFile(final Path file) throws IOException {
+  public CompilationUnit parseJavaFile(final Path file, final String contents) {
     if (cache.containsKey(file)) {
       return cache.get(file);
     }
-    try (InputStream in = Files.newInputStream(file)) {
-      final ParseResult<CompilationUnit> result = parser.parse(in);
-      if (!result.isSuccessful()) {
-        throw new RuntimeException("can't parse file");
-      }
-      CompilationUnit cu = result.getResult().orElseThrow();
-      LexicalPreservingPrinter.setup(cu);
-      cache.put(file, cu);
-      return cu;
+    final ParseResult<CompilationUnit> result = parser.parse(contents);
+    if (!result.isSuccessful()) {
+      throw new RuntimeException("can't parse file");
     }
+    CompilationUnit cu = result.getResult().orElseThrow();
+    LexicalPreservingPrinter.setup(cu);
+    cache.put(file, cu);
+    return cu;
   }
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserCodemodRunner.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserCodemodRunner.java
@@ -42,7 +42,7 @@ public final class JavaParserCodemodRunner implements CodemodRunner {
   @Override
   public List<CodemodChange> run(final CodemodInvocationContext context) throws IOException {
     Path file = context.path();
-    CompilationUnit cu = parser.parseJavaFile(file);
+    CompilationUnit cu = parser.parseJavaFile(file, context.contents());
     List<CodemodChange> changes = javaParserChanger.visit(context, cu);
     if (!changes.isEmpty()) {
       String encodingName = encodingDetector.detect(file).orElse("UTF-8");

--- a/framework/codemodder-base/src/test/java/io/codemodder/CodemodLoaderTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/CodemodLoaderTest.java
@@ -167,6 +167,7 @@ final class CodemodLoaderTest {
               codemodIdPair,
               List.of(),
               List.of(),
+              FileCache.createDefault(),
               CachingJavaParser.from(new JavaParser()),
               EncodingDetector.create());
       executor.execute(List.of(file));
@@ -301,6 +302,7 @@ final class CodemodLoaderTest {
               pair,
               List.of(),
               List.of(),
+              FileCache.createDefault(),
               CachingJavaParser.from(new JavaParser()),
               EncodingDetector.create());
       Path p = tmpDir.resolve("foo.txt");

--- a/framework/codemodder-base/src/test/java/io/codemodder/DefaultCodemodExecutorTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/DefaultCodemodExecutorTest.java
@@ -40,6 +40,7 @@ final class DefaultCodemodExecutorTest {
   private IncludesExcludes includesEverything;
   private BeforeToAfterChanger beforeToAfterChanger;
   private CodemodIdPair beforeAfterCodemod;
+  private FileCache fileCache;
 
   @BeforeEach
   void setup(final @TempDir Path tmpDir) throws IOException {
@@ -49,6 +50,7 @@ final class DefaultCodemodExecutorTest {
     cachingJavaParser = CachingJavaParser.from(new JavaParser());
     encodingDetector = EncodingDetector.create();
     includesEverything = IncludesExcludes.any();
+    fileCache = FileCache.createDefault();
     executor =
         new DefaultCodemodExecutor(
             repoDir,
@@ -56,6 +58,7 @@ final class DefaultCodemodExecutorTest {
             beforeAfterCodemod,
             List.of(),
             List.of(),
+            fileCache,
             cachingJavaParser,
             encodingDetector);
 
@@ -179,6 +182,7 @@ final class DefaultCodemodExecutorTest {
             beforeAfterCodemod,
             List.of(),
             List.of(addsPrefixProvider),
+            fileCache,
             cachingJavaParser,
             encodingDetector);
 
@@ -243,6 +247,7 @@ final class DefaultCodemodExecutorTest {
               codemod,
               List.of(depsProvider),
               List.of(),
+              fileCache,
               CachingJavaParser.from(new JavaParser()),
               EncodingDetector.create());
       CodeTFResult result = executor.execute(List.of(javaFile2, javaFile4));
@@ -368,6 +373,7 @@ final class DefaultCodemodExecutorTest {
             codemod,
             List.of(badProvider),
             List.of(),
+            fileCache,
             CachingJavaParser.from(new JavaParser()),
             EncodingDetector.create());
     CodeTFResult result = executor.execute(List.of(javaFile2, javaFile4));
@@ -420,6 +426,7 @@ final class DefaultCodemodExecutorTest {
             codemod,
             List.of(skippingProvider),
             List.of(),
+            fileCache,
             CachingJavaParser.from(new JavaParser()),
             EncodingDetector.create());
     CodeTFResult result = executor.execute(List.of(javaFile2));

--- a/framework/codemodder-base/src/test/java/io/codemodder/FileCacheTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/FileCacheTest.java
@@ -1,0 +1,72 @@
+package io.codemodder;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class FileCacheTest {
+
+  private Path file1;
+  private Path file2;
+  private Path file3;
+  private FileCache fileCache;
+
+  @BeforeEach
+  void setup(@TempDir final Path tmpDir) throws IOException {
+    this.file1 = tmpDir.resolve("file1");
+    this.file2 = tmpDir.resolve("file2");
+    this.file3 = tmpDir.resolve("file3");
+
+    Files.writeString(file1, "1");
+    Files.writeString(file2, "2");
+    Files.writeString(file3, "3");
+
+    fileCache = FileCache.createDefault(2);
+  }
+
+  @Test
+  void it_caches_correctly() throws IOException {
+    String file1Contents = fileCache.get(file1);
+
+    // not only should it be identical...
+    assertThat(file1Contents).isEqualTo("1");
+
+    // ... but it should also be the same pointer
+    assertThat(file1Contents).isSameAs(file1Contents);
+  }
+
+  @Test
+  void it_respects_max() throws IOException {
+    String file1Contents = fileCache.get(file1);
+    String file2Contents = fileCache.get(file2);
+
+    assertThat(file1Contents).isSameAs(file1Contents);
+    assertThat(file2Contents).isSameAs(file2Contents);
+
+    String file3Contents = fileCache.get(file3);
+    assertThat(file3Contents).isEqualTo(fileCache.get(file3));
+    assertThat(file3Contents).isEqualTo("3");
+
+    // confirm that the cache didn't retain
+    String file3ContentsAgain = fileCache.get(file3);
+    assertThat(file3Contents).isNotSameAs(file3ContentsAgain);
+  }
+
+  @Test
+  void it_overrides() throws IOException {
+    String file1Contents = fileCache.get(file1);
+    assertThat(file1Contents).isEqualTo("1");
+    fileCache.overrideEntry(file1, "skadoodle");
+    assertThat(fileCache.get(file1)).isEqualTo("skadoodle");
+
+    // we don't have an entry for file3, so attempting to override it should cause an error
+    assertThrows(
+        IllegalArgumentException.class, () -> fileCache.overrideEntry(file3, "irrelevant"));
+  }
+}

--- a/framework/codemodder-base/src/test/java/io/codemodder/javaparser/JavaParserCodemodRunnerTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/javaparser/JavaParserCodemodRunnerTest.java
@@ -108,6 +108,7 @@ final class JavaParserCodemodRunnerTest {
     when(context.codemodId()).thenReturn("my-codemod-id");
     when(context.lineIncludesExcludes()).thenReturn(new LineIncludesExcludes.MatchesEverything());
     when(context.path()).thenReturn(javaFile);
+    when(context.contents()).thenReturn(javaCode);
     CodeDirectory dir = mock(CodeDirectory.class);
     when(dir.asPath()).thenReturn(tmpDir);
     when(context.codeDirectory()).thenReturn(dir);
@@ -141,6 +142,7 @@ final class JavaParserCodemodRunnerTest {
     when(context.codemodId()).thenReturn("pixee-test:java/my-composite");
     when(context.lineIncludesExcludes()).thenReturn(new LineIncludesExcludes.MatchesEverything());
     when(context.path()).thenReturn(javaFile);
+    when(context.contents()).thenReturn(javaCode);
     CodeDirectory dir = mock(CodeDirectory.class);
     when(dir.asPath()).thenReturn(tmpDir);
     when(context.codeDirectory()).thenReturn(dir);

--- a/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/CodemodTestMixin.java
+++ b/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/CodemodTestMixin.java
@@ -117,6 +117,7 @@ public interface CodemodTestMixin {
             codemod,
             List.of(),
             List.of(),
+            FileCache.createDefault(),
             CachingJavaParser.from(factory.create(List.of(dir))),
             EncodingDetector.create());
     CodeTFResult result = executor.execute(List.of(pathToJavaFile));
@@ -171,6 +172,7 @@ public interface CodemodTestMixin {
             codemod2,
             List.of(),
             List.of(),
+            FileCache.createDefault(),
             CachingJavaParser.from(factory.create(List.of(dir))),
             EncodingDetector.create());
     CodeTFResult result2 = executor2.execute(List.of(pathToJavaFile));

--- a/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/RawFileCodemodTest.java
+++ b/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/RawFileCodemodTest.java
@@ -66,6 +66,7 @@ public interface RawFileCodemodTest {
             pair,
             List.of(),
             List.of(),
+            FileCache.createDefault(),
             CachingJavaParser.from(new JavaParser()),
             EncodingDetector.create());
     CodeTFResult result = executor.execute(List.of(tmpFilePath));


### PR DESCRIPTION
This change introduces a file cache which will reduce the redundant roundtrip I/O to disk for each codemod. It will increase memory pressure relative to the size of the project being scanned.