### PR TITLE
Make sure scanners don't scan files that aren't inspected

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java
@@ -43,14 +43,14 @@ public final class MavenSecureURLCodemod extends SarifPluginRawFileChanger {
   public List<CodemodChange> onFileFound(
       final CodemodInvocationContext context, final List<Result> results) {
     try {
-      return processXml(context, context.path());
+      return processXml(context.path());
     } catch (SAXException | DocumentException | IOException | XMLStreamException e) {
       LOG.error("Problem transforming xml file: {}", context.path());
       return List.of();
     }
   }
 
-  private List<CodemodChange> processXml(final CodemodInvocationContext context, final Path file)
+  private List<CodemodChange> processXml(final Path file)
       throws SAXException, IOException, DocumentException, XMLStreamException {
     Optional<XPathStreamProcessChange> change =
         processor.process(

--- a/core-codemods/src/test/java/io/codemodder/codemods/AddMissingI18nCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/AddMissingI18nCodemodTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -220,8 +221,8 @@ final class AddMissingI18nCodemodTest {
         is(true));
   }
 
-  private CodeTFResult runCodemod() {
-    var loader = new CodemodLoader(List.of(AddMissingI18nCodemod.class), repoRoot);
+  private CodeTFResult runCodemod() throws IOException {
+    CodemodLoader loader = createLoader(AddMissingI18nCodemod.class, repoRoot);
     List<CodemodIdPair> codemods = loader.getCodemods();
     assertThat("Only expecting 1 codemod per test", codemods.size(), equalTo(1));
     CodemodIdPair pair = codemods.get(0);
@@ -239,6 +240,19 @@ final class AddMissingI18nCodemodTest {
             repoRoot.resolve("whatever_en_US.properties"),
             repoRoot.resolve("whatever_es_MX.properties"),
             repoRoot.resolve("whatever_bg.properties")));
+  }
+
+  private CodemodLoader createLoader(final Class<? extends CodeChanger> codemodType, final Path dir)
+      throws IOException {
+    return new CodemodLoader(
+        List.of(codemodType),
+        CodemodRegulator.of(DefaultRuleSetting.ENABLED, List.of()),
+        repoRoot,
+        List.of("**"),
+        List.of(),
+        Files.list(dir).toList(),
+        Map.of(),
+        List.of());
   }
 
   /** If we can't connect to AWS, skip the test. */

--- a/core-codemods/src/test/java/io/codemodder/codemods/JSPScriptletXSSCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/JSPScriptletXSSCodemodTest.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -34,11 +35,21 @@ final class JSPScriptletXSSCodemodTest {
       throws IOException {
     String dir = "src/test/resources/encode-jsp-scriptlet/" + jspDir;
     copyDir(Path.of(dir), tmpDir);
-    CodemodLoader codemodInvoker = new CodemodLoader(List.of(JSPScriptletXSSCodemod.class), tmpDir);
 
     Path beforeJsp = tmpDir.resolve("test.jsp.before");
     Path jsp = tmpDir.resolve("test.jsp");
     Files.copy(beforeJsp, jsp);
+
+    CodemodLoader codemodInvoker =
+        new CodemodLoader(
+            List.of(JSPScriptletXSSCodemod.class),
+            CodemodRegulator.of(DefaultRuleSetting.ENABLED, List.of()),
+            tmpDir,
+            List.of("**"),
+            List.of(),
+            List.of(jsp),
+            Map.of(),
+            List.of());
     CodemodIdPair codemod = codemodInvoker.getCodemods().get(0);
     CodemodExecutor executor =
         CodemodExecutor.from(

--- a/core-codemods/src/test/java/io/codemodder/codemods/VerbTamperingCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/VerbTamperingCodemodTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -46,8 +47,20 @@ final class VerbTamperingCodemodTest {
       throws IOException {
     String dir = "src/test/resources/verb-tampering/" + webXmlDir;
     copyDir(Path.of(dir), tmpDir);
-    CodemodLoader loader = new CodemodLoader(List.of(VerbTamperingCodemod.class), tmpDir);
+
     Path webxml = tmpDir.resolve("web.xml");
+
+    CodemodLoader loader =
+        new CodemodLoader(
+            List.of(VerbTamperingCodemod.class),
+            CodemodRegulator.of(DefaultRuleSetting.ENABLED, List.of()),
+            tmpDir,
+            List.of("**"),
+            List.of(),
+            List.of(webxml),
+            Map.of(),
+            List.of());
+
     CodemodExecutor executor =
         CodemodExecutor.from(
             tmpDir,

--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -336,7 +336,15 @@ final class CLI implements Callable<Integer> {
       List<ParameterArgument> codemodParameters =
           createFromParameterStrings(this.codemodParameters);
       CodemodLoader loader =
-          new CodemodLoader(codemodTypes, regulator, projectPath, pathSarifMap, codemodParameters);
+          new CodemodLoader(
+              codemodTypes,
+              regulator,
+              projectPath,
+              pathIncludes,
+              pathExcludes,
+              filePaths,
+              pathSarifMap,
+              codemodParameters);
       List<CodemodIdPair> codemods = loader.getCodemods();
 
       log.debug("sarif files: {}", sarifFiles.size());

--- a/framework/codemodder-base/src/main/java/io/codemodder/CodemodLoader.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodemodLoader.java
@@ -20,43 +20,12 @@ public final class CodemodLoader {
   private final List<CodemodIdPair> codemods;
 
   public CodemodLoader(
-      final List<Class<? extends CodeChanger>> codemodTypes, final Path repositoryDir) {
-    this(
-        codemodTypes,
-        CodemodRegulator.of(DefaultRuleSetting.ENABLED, List.of()),
-        repositoryDir,
-        Map.of(),
-        List.of());
-  }
-
-  public CodemodLoader(
-      final List<Class<? extends CodeChanger>> codemodTypes,
-      final Path repositoryDir,
-      final List<ParameterArgument> parameterArguments) {
-    this(
-        codemodTypes,
-        CodemodRegulator.of(DefaultRuleSetting.ENABLED, List.of()),
-        repositoryDir,
-        Map.of(),
-        parameterArguments);
-  }
-
-  public CodemodLoader(
-      final List<Class<? extends CodeChanger>> codemodTypes,
-      final Path repositoryDir,
-      final Map<String, List<RuleSarif>> ruleSarifByTool) {
-    this(
-        codemodTypes,
-        CodemodRegulator.of(DefaultRuleSetting.ENABLED, List.of()),
-        repositoryDir,
-        ruleSarifByTool,
-        List.of());
-  }
-
-  public CodemodLoader(
       final List<Class<? extends CodeChanger>> codemodTypes,
       final CodemodRegulator codemodRegulator,
       final Path repositoryDir,
+      final List<String> pathIncludes,
+      final List<String> pathExcludes,
+      final List<Path> includedFiles,
       final Map<String, List<RuleSarif>> ruleSarifByTool,
       final List<ParameterArgument> codemodParameters) {
 
@@ -110,7 +79,13 @@ public final class CodemodLoader {
               .flatMap(toolName -> ruleSarifByTool.getOrDefault(toolName, List.of()).stream())
               .toList();
       final Set<AbstractModule> modules =
-          provider.getModules(repositoryDir, codemodTypes, allWantedSarifs);
+          provider.getModules(
+              repositoryDir,
+              includedFiles,
+              pathIncludes,
+              pathExcludes,
+              codemodTypes,
+              allWantedSarifs);
       allModules.addAll(modules);
     }
 

--- a/framework/codemodder-base/src/main/java/io/codemodder/CodemodProvider.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodemodProvider.java
@@ -14,15 +14,29 @@ public interface CodemodProvider {
   /**
    * Return a set of Guice modules that allow dependency injection
    *
+   * @param repository the repository root
+   * @param codemodTypes the codemod types that are being run
+   * @param sarifs the SARIF output of tools that are being run
+   * @param includedFiles the files that qualify for inclusion based on the patterns provided
+   * @param pathIncludes the path includes provided to the CLI (which could inform the providers on
+   *     their own analysis)
+   * @param pathExcludes the path excludes provided to the CLI (which could inform the providers on
+   *     their own analysis)
    * @return a set of modules that perform dependency injection
    */
   Set<AbstractModule> getModules(
-      Path repository, List<Class<? extends CodeChanger>> codemodTypes, List<RuleSarif> sarifs);
+      Path repository,
+      List<Path> includedFiles,
+      List<String> pathIncludes,
+      List<String> pathExcludes,
+      List<Class<? extends CodeChanger>> codemodTypes,
+      List<RuleSarif> sarifs);
 
   /**
    * Tools this provider is interested in processing the SARIF output of. Codemodder CLI will look
    * for the SARIF outputted by tools in this list in the repository root and then provide the
-   * results to {@link #getModules(Path, List, List)} as a {@link List} of {@link RuleSarif}s.
+   * results to {@link #getModules(Path, List, List, List, List, List)} as a {@link List} of {@link
+   * RuleSarif}s.
    *
    * <p>By default, this returns an empty list.
    *

--- a/framework/codemodder-base/src/main/java/io/codemodder/SarifPluginRawFileChanger.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/SarifPluginRawFileChanger.java
@@ -1,7 +1,6 @@
 package io.codemodder;
 
 import com.contrastsecurity.sarif.Result;
-import java.io.IOException;
 import java.util.List;
 
 /** A {@link RawFileChanger} bundled with a {@link RuleSarif}. */
@@ -20,11 +19,10 @@ public abstract class SarifPluginRawFileChanger extends RawFileChanger {
   }
 
   @Override
-  public List<CodemodChange> visitFile(final CodemodInvocationContext context) throws IOException {
+  public List<CodemodChange> visitFile(final CodemodInvocationContext context) {
     List<Result> results = sarif.getResultsByPath(context.path());
     if (!results.isEmpty()) {
-      List<CodemodChange> allChanges = onFileFound(context, results);
-      return allChanges;
+      return onFileFound(context, results);
     }
     return List.of();
   }

--- a/framework/codemodder-base/src/test/java/io/codemodder/CodemodLoaderTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/CodemodLoaderTest.java
@@ -363,7 +363,4 @@ final class CodemodLoaderTest {
         Map.of(),
         params);
   }
-
-  private static List<String> ALL_PATTERN = List.of("**");
-  private static List<String> NONE_PATTERN = List.of();
 }

--- a/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/CodemodTestMixin.java
+++ b/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/CodemodTestMixin.java
@@ -103,7 +103,16 @@ public interface CodemodTestMixin {
     }
 
     // run the codemod
-    CodemodLoader loader = new CodemodLoader(List.of(codemodType), tmpDir, map);
+    CodemodLoader loader =
+        new CodemodLoader(
+            List.of(codemodType),
+            CodemodRegulator.of(DefaultRuleSetting.ENABLED, List.of()),
+            tmpDir,
+            List.of("**"),
+            List.of(),
+            List.of(pathToJavaFile),
+            map,
+            List.of());
 
     List<CodemodIdPair> codemods = loader.getCodemods();
     assertThat(codemods.size(), equalTo(1));
@@ -162,7 +171,16 @@ public interface CodemodTestMixin {
     String codeAfterFirstTransform = Files.readString(pathToJavaFile);
 
     // re-run the transformation again and make sure no changes are made
-    CodemodLoader loader2 = new CodemodLoader(List.of(codemodType), tmpDir, map);
+    CodemodLoader loader2 =
+        new CodemodLoader(
+            List.of(codemodType),
+            CodemodRegulator.of(DefaultRuleSetting.ENABLED, List.of()),
+            tmpDir,
+            List.of("**"),
+            List.of(),
+            List.of(pathToJavaFile),
+            map,
+            List.of());
     CodemodIdPair codemod2 = loader2.getCodemods().get(0);
     CodemodExecutor executor2 =
         CodemodExecutor.from(

--- a/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/RawFileCodemodTest.java
+++ b/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/RawFileCodemodTest.java
@@ -40,7 +40,8 @@ public interface RawFileCodemodTest {
       final Path tmpDir,
       final Metadata metadata,
       final Path filePathBefore,
-      final Path filePathAfter)
+      final Path filePathAfter,
+      final Map<String, List<RuleSarif>> ruleSarifMap)
       throws IOException {
 
     String tmpFileName = trimExtension(filePathBefore);
@@ -63,7 +64,7 @@ public interface RawFileCodemodTest {
             List.of("**"),
             List.of(),
             List.of(tmpFilePath),
-            Map.of(),
+            ruleSarifMap,
             List.of());
     List<CodemodIdPair> codemods = loader.getCodemods();
     assertThat("Only expecting 1 codemod per test", codemods.size(), equalTo(1));
@@ -127,7 +128,7 @@ public interface RawFileCodemodTest {
     for (var beforeFile : allBeforeFiles) {
       final var afterFile = afterFilesMap.get(trimExtension(beforeFile));
       // run the codemod
-      verifySingleCase(codemod, tmpDir, metadata, beforeFile, afterFile);
+      verifySingleCase(codemod, tmpDir, metadata, beforeFile, afterFile, map);
     }
   }
 }

--- a/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/RawFileCodemodTest.java
+++ b/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/RawFileCodemodTest.java
@@ -105,7 +105,16 @@ public interface RawFileCodemodTest {
         SarifParser.create().parseIntoMap(allSarifFiles, tmpDir);
 
     // run the codemod
-    final CodemodLoader invoker = new CodemodLoader(List.of(codemod), tmpDir, map);
+    final CodemodLoader invoker =
+        new CodemodLoader(
+            List.of(codemod),
+            CodemodRegulator.of(DefaultRuleSetting.ENABLED, List.of()),
+            tmpDir,
+            List.of("**"),
+            List.of(),
+            Files.list(tmpDir).toList(),
+            Map.of(),
+            List.of());
 
     // grab all the .before and .after files in the dir
     final var allBeforeFiles =

--- a/plugins/codemodder-plugin-aws/src/main/java/io/codemodder/plugins/aws/AwsProvider.java
+++ b/plugins/codemodder-plugin-aws/src/main/java/io/codemodder/plugins/aws/AwsProvider.java
@@ -14,6 +14,9 @@ public final class AwsProvider implements CodemodProvider {
   @Override
   public Set<AbstractModule> getModules(
       final Path codeDirectory,
+      final List<Path> includedFiles,
+      final List<String> includePaths,
+      final List<String> excludePaths,
       final List<Class<? extends CodeChanger>> codemodTypes,
       final List<RuleSarif> sarifs) {
     return Set.of(new AwsClientModule());

--- a/plugins/codemodder-plugin-codeql/src/main/java/io/codemodder/providers/sarif/codeql/CodeQLProvider.java
+++ b/plugins/codemodder-plugin-codeql/src/main/java/io/codemodder/providers/sarif/codeql/CodeQLProvider.java
@@ -14,6 +14,9 @@ public final class CodeQLProvider implements CodemodProvider {
   @Override
   public Set<AbstractModule> getModules(
       final Path repository,
+      final List<Path> includedFiles,
+      final List<String> includePaths,
+      final List<String> excludePaths,
       final List<Class<? extends CodeChanger>> codemodTypes,
       final List<RuleSarif> sarifs) {
     return Set.of(new CodeQLModule(codemodTypes, sarifs));

--- a/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/LLMProvider.java
+++ b/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/LLMProvider.java
@@ -14,6 +14,9 @@ public final class LLMProvider implements CodemodProvider {
   @Override
   public Set<AbstractModule> getModules(
       final Path repository,
+      final List<Path> includedFiles,
+      final List<String> includePaths,
+      final List<String> excludePaths,
       final List<Class<? extends CodeChanger>> codemodTypes,
       final List<RuleSarif> sarifs) {
     return Set.of(new LLMServiceModule());

--- a/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/DefaultPmdRunner.java
+++ b/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/DefaultPmdRunner.java
@@ -24,7 +24,8 @@ final class DefaultPmdRunner implements PmdRunner {
   }
 
   @Override
-  public SarifSchema210 run(final List<String> ruleIds, final Path projectDir) {
+  public SarifSchema210 run(
+      final List<String> ruleIds, final Path projectDir, final List<Path> includedFiles) {
     // configure the PMD run
     PMDConfiguration config = new PMDConfiguration();
     config.setDefaultLanguageVersion(LanguageRegistry.PMD.getLanguageVersionById("java", null));
@@ -64,7 +65,7 @@ final class DefaultPmdRunner implements PmdRunner {
       config.setReportFile(sarifFile);
 
       // calculate the source directories for PMD to scan (only looks for src/main/java now)
-      config.addInputPath(projectDir);
+      includedFiles.forEach(config::addInputPath);
 
       // run the analysis
       try (PmdAnalysis pmd = PmdAnalysis.create(config)) {

--- a/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdModule.java
+++ b/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdModule.java
@@ -20,11 +20,15 @@ public final class PmdModule extends AbstractModule {
   private final List<Class<? extends CodeChanger>> codemodTypes;
   private final Path codeDirectory;
   private final PmdRunner pmdRunner;
+  private final List<Path> includedFiles;
 
   public PmdModule(
-      final Path codeDirectory, final List<Class<? extends CodeChanger>> codemodTypes) {
+      final Path codeDirectory,
+      final List<Path> includedFiles,
+      final List<Class<? extends CodeChanger>> codemodTypes) {
     this.codemodTypes = Objects.requireNonNull(codemodTypes);
     this.codeDirectory = Objects.requireNonNull(codeDirectory);
+    this.includedFiles = Objects.requireNonNull(includedFiles);
     this.pmdRunner = PmdRunner.createDefault();
   }
 
@@ -88,7 +92,7 @@ public final class PmdModule extends AbstractModule {
     }
 
     List<String> rules = toBind.stream().map(Pair::getLeft).toList();
-    SarifSchema210 sarif = pmdRunner.run(rules, codeDirectory);
+    SarifSchema210 sarif = pmdRunner.run(rules, codeDirectory, includedFiles);
 
     // bind the SARIF results to individual codemods
     for (Pair<String, PmdScan> bindingPair : toBind) {

--- a/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdProvider.java
+++ b/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdProvider.java
@@ -14,8 +14,11 @@ public final class PmdProvider implements CodemodProvider {
   @Override
   public Set<AbstractModule> getModules(
       final Path codeDirectory,
+      final List<Path> includedFiles,
+      final List<String> includePaths,
+      final List<String> excludePaths,
       final List<Class<? extends CodeChanger>> codemodTypes,
       final List<RuleSarif> sarifs) {
-    return Set.of(new PmdModule(codeDirectory, codemodTypes));
+    return Set.of(new PmdModule(codeDirectory, includedFiles, codemodTypes));
   }
 }

--- a/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdRunner.java
+++ b/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdRunner.java
@@ -12,9 +12,10 @@ public interface PmdRunner {
    *
    * @param ruleIds the rule IDs to run (the rules must be in the default PMD ruleset)
    * @param codeDir the directory containing the code to be run on
+   * @param includedFiles the files to be included in the scan
    * @return the resulting SARIF
    */
-  SarifSchema210 run(List<String> ruleIds, Path codeDir);
+  SarifSchema210 run(List<String> ruleIds, Path codeDir, List<Path> includedFiles);
 
   static PmdRunner createDefault() {
     return new DefaultPmdRunner();

--- a/plugins/codemodder-plugin-pmd/src/test/java/io/codemodder/providers/sarif/pmd/DefaultPmdRunnerTest.java
+++ b/plugins/codemodder-plugin-pmd/src/test/java/io/codemodder/providers/sarif/pmd/DefaultPmdRunnerTest.java
@@ -52,13 +52,13 @@ final class DefaultPmdRunnerTest {
   }
 
   @Test
-  void it_runs_and_finds_stuff() {
+  void it_runs_and_finds_stuff() throws IOException {
     DefaultPmdRunner runner = new DefaultPmdRunner();
     List<String> ruleIds =
         List.of(
             "category/java/bestpractices.xml/OneDeclarationPerLine",
             "category/java/bestpractices.xml/MissingOverride");
-    SarifSchema210 sarif = runner.run(ruleIds, projectDir);
+    SarifSchema210 sarif = runner.run(ruleIds, projectDir, Files.list(projectDir).toList());
     assertThat(sarif.getRuns()).hasSize(1);
     Run run = sarif.getRuns().get(0);
     List<Result> results = run.getResults();

--- a/plugins/codemodder-plugin-pmd/src/test/java/io/codemodder/providers/sarif/pmd/PmdModuleTest.java
+++ b/plugins/codemodder-plugin-pmd/src/test/java/io/codemodder/providers/sarif/pmd/PmdModuleTest.java
@@ -35,7 +35,7 @@ final class PmdModuleTest {
                     }
                     """);
 
-    PmdModule module = new PmdModule(tmpDir, List.of(UsesPmdCodemod.class));
+    PmdModule module = new PmdModule(tmpDir, List.of(javaFile), List.of(UsesPmdCodemod.class));
     Injector injector = Guice.createInjector(module);
     UsesPmdCodemod codemod = injector.getInstance(UsesPmdCodemod.class);
     RuleSarif ruleSarif = codemod.ruleSarif;

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/DefaultSemgrepRunner.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/DefaultSemgrepRunner.java
@@ -20,7 +20,12 @@ final class DefaultSemgrepRunner implements SemgrepRunner {
   }
 
   @Override
-  public SarifSchema210 run(final List<Path> ruleYamls, final Path repository) throws IOException {
+  public SarifSchema210 run(
+      final List<Path> ruleYamls,
+      final Path repository,
+      final List<String> includePatterns,
+      final List<String> excludePatterns)
+      throws IOException {
     Path repositoryPath = repository.toAbsolutePath();
     Path sarifFile = Files.createTempFile("semgrep", ".sarif");
 
@@ -32,6 +37,16 @@ final class DefaultSemgrepRunner implements SemgrepRunner {
     args.add("--sarif");
     args.add("-o");
     args.add(sarifFile.toAbsolutePath().toString());
+
+    for (String includedFilePath : includePatterns) {
+      args.add("--include");
+      args.add(includedFilePath);
+    }
+
+    for (String excludedFilePath : excludePatterns) {
+      args.add("--exclude");
+      args.add(excludedFilePath);
+    }
 
     for (Path ruleYamlPath : ruleYamls) {
       args.add("--config");

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepModule.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepModule.java
@@ -30,18 +30,28 @@ public final class SemgrepModule extends AbstractModule {
   private final Path codeDirectory;
   private final SemgrepRunner semgrepRunner;
   private final List<RuleSarif> sarifs;
+  private final List<String> includePatterns;
+  private final List<String> excludePatterns;
 
   @VisibleForTesting
-  SemgrepModule(final Path codeDirectory, final List<Class<? extends CodeChanger>> codemodTypes) {
-    this(codeDirectory, codemodTypes, List.of());
+  SemgrepModule(
+      final Path codeDirectory,
+      final List<String> includePatterns,
+      final List<String> excludePatterns,
+      final List<Class<? extends CodeChanger>> codemodTypes) {
+    this(codeDirectory, includePatterns, excludePatterns, codemodTypes, List.of());
   }
 
   public SemgrepModule(
       final Path codeDirectory,
+      final List<String> includePatterns,
+      final List<String> excludePatterns,
       final List<Class<? extends CodeChanger>> codemodTypes,
       final List<RuleSarif> sarifs) {
     this.codemodTypes = Objects.requireNonNull(codemodTypes);
     this.codeDirectory = Objects.requireNonNull(codeDirectory);
+    this.includePatterns = Objects.requireNonNull(includePatterns);
+    this.excludePatterns = Objects.requireNonNull(excludePatterns);
     this.semgrepRunner = SemgrepRunner.createDefault();
     this.sarifs = Objects.requireNonNull(sarifs);
   }
@@ -216,7 +226,7 @@ public final class SemgrepModule extends AbstractModule {
     // actually run the SARIF only once
     SarifSchema210 sarif;
     try {
-      sarif = semgrepRunner.run(yamlPathsToRun, codeDirectory);
+      sarif = semgrepRunner.run(yamlPathsToRun, codeDirectory, includePatterns, excludePatterns);
     } catch (IOException e) {
       throw new IllegalArgumentException("Semgrep execution failed", e);
     }

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepProvider.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepProvider.java
@@ -14,9 +14,13 @@ public final class SemgrepProvider implements CodemodProvider {
   @Override
   public Set<AbstractModule> getModules(
       final Path codeDirectory,
+      final List<Path> includedFiles,
+      final List<String> includePaths,
+      final List<String> excludePaths,
       final List<Class<? extends CodeChanger>> codemodTypes,
       final List<RuleSarif> sarifs) {
-    return Set.of(new SemgrepModule(codeDirectory, codemodTypes, sarifs));
+    return Set.of(
+        new SemgrepModule(codeDirectory, includePaths, excludePaths, codemodTypes, sarifs));
   }
 
   @Override

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRunner.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRunner.java
@@ -15,7 +15,9 @@ public interface SemgrepRunner {
    * @param codeDir the directory containing the code to be run on
    * @return the resulting SARIF
    */
-  SarifSchema210 run(List<Path> yamls, Path codeDir) throws IOException;
+  SarifSchema210 run(
+      List<Path> yamls, Path codeDir, List<String> includePatterns, List<String> excludePatterns)
+      throws IOException;
 
   static SemgrepRunner createDefault() {
     return new DefaultSemgrepRunner();

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepJavaParserChangerTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepJavaParserChangerTest.java
@@ -32,7 +32,9 @@ final class SemgrepJavaParserChangerTest {
     String javaCode = "class Foo { \n\n  Object a = new Stuff();\n  Object b = new That();\n }";
     Path javaFile = writeJavaFile(tmpDir, javaCode);
 
-    SemgrepModule module = new SemgrepModule(tmpDir, List.of(UsesInlineSemgrepCodemod.class));
+    SemgrepModule module =
+        new SemgrepModule(
+            tmpDir, List.of("**"), List.of(), List.of(UsesInlineSemgrepCodemod.class));
     Injector injector = Guice.createInjector(module);
     UsesInlineSemgrepCodemod instance = injector.getInstance(UsesInlineSemgrepCodemod.class);
     RuleSarif ruleSarif = instance.sarif;
@@ -42,7 +44,9 @@ final class SemgrepJavaParserChangerTest {
 
   @Test
   void it_fails_when_both_used(@TempDir Path tmpDir) {
-    SemgrepModule module = new SemgrepModule(tmpDir, List.of(InvalidUsesBothYamlStrategies.class));
+    SemgrepModule module =
+        new SemgrepModule(
+            tmpDir, List.of("**"), List.of(), List.of(InvalidUsesBothYamlStrategies.class));
     assertThrows(CreationException.class, () -> Guice.createInjector(module));
   }
 

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepModuleTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepModuleTest.java
@@ -168,7 +168,7 @@ final class SemgrepModuleTest {
     String javaCode = "class Foo { \n Object a = new Thing(); \n }";
     Path javaFile = Files.createTempFile(tmpDir, "HasThing", ".java");
     Files.writeString(javaFile, javaCode, StandardOpenOption.TRUNCATE_EXISTING);
-    SemgrepModule module = new SemgrepModule(tmpDir, List.of(UsesImplicitYamlPath.class));
+    SemgrepModule module = createModule(tmpDir, List.of(UsesImplicitYamlPath.class));
     Injector injector = Guice.createInjector(module);
     UsesImplicitYamlPath instance = injector.getInstance(UsesImplicitYamlPath.class);
 
@@ -186,7 +186,7 @@ final class SemgrepModuleTest {
     Path javaFile = Files.createTempFile(tmpDir, "HasStuff", ".java");
     Files.writeString(javaFile, javaCode, StandardOpenOption.TRUNCATE_EXISTING);
 
-    SemgrepModule module = new SemgrepModule(tmpDir, List.of(codemod));
+    SemgrepModule module = createModule(tmpDir, List.of(codemod));
     Injector injector = Guice.createInjector(module);
     SarifPluginJavaParserChanger<ObjectCreationExpr> instance =
         (SarifPluginJavaParserChanger<ObjectCreationExpr>) injector.getInstance(codemod);
@@ -197,7 +197,7 @@ final class SemgrepModuleTest {
 
   @Test
   void it_detects_rule_ids(final @TempDir Path tmpDir) throws IOException {
-    SemgrepModule module = new SemgrepModule(tmpDir, List.of(UsesImplicitYamlPath.class));
+    SemgrepModule module = createModule(tmpDir, List.of(UsesImplicitYamlPath.class));
 
     String id = module.detectSingleRuleFromYaml("rules:\n  - id: foo\n    pattern: bar\n");
     assertThat(id, is("foo"));
@@ -210,6 +210,11 @@ final class SemgrepModuleTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> module.detectSingleRuleFromYaml("rules:\n  - pattern: baz\n"));
+  }
+
+  private SemgrepModule createModule(
+      final Path dir, final List<Class<? extends CodeChanger>> codemodTypes) throws IOException {
+    return new SemgrepModule(dir, List.of("**"), List.of(), codemodTypes);
   }
 
   static Stream<Arguments> codemodsThatLookForNewStuffInstances() {
@@ -234,6 +239,8 @@ final class SemgrepModuleTest {
     SemgrepModule module =
         new SemgrepModule(
             tmpDir,
+            List.of("**"),
+            List.of(),
             List.of(UsesOfflineSemgrepCodemod.class),
             map.entrySet().iterator().next().getValue());
     Injector injector = Guice.createInjector(module);

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepRunnerTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepRunnerTest.java
@@ -32,7 +32,8 @@ final class SemgrepRunnerTest {
     Files.copy(resourceAsStream, ruleFile, StandardCopyOption.REPLACE_EXISTING);
 
     // run the scan
-    SarifSchema210 sarif = new DefaultSemgrepRunner().run(List.of(ruleFile), repositoryDir);
+    SarifSchema210 sarif =
+        new DefaultSemgrepRunner().run(List.of(ruleFile), repositoryDir, List.of("**"), List.of());
 
     // assert the scan went as we think it should
     List<Run> runs = sarif.getRuns();

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bindstoincorrect/BindsToIncorrectObjectTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bindstoincorrect/BindsToIncorrectObjectTest.java
@@ -15,7 +15,8 @@ final class BindsToIncorrectObjectTest {
   @Test
   void it_fails_when_injecting_nonsarif_type(@TempDir Path tmpDir) {
     SemgrepModule module =
-        new SemgrepModule(tmpDir, List.of(BindsToIncorrectObject.class), List.of());
+        new SemgrepModule(
+            tmpDir, List.of("**"), List.of(), List.of(BindsToIncorrectObject.class), List.of());
     assertThrows(
         CreationException.class,
         () -> {

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bothyamlstrategies/InvalidUsesBothYamlStrategiesTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bothyamlstrategies/InvalidUsesBothYamlStrategiesTest.java
@@ -15,7 +15,12 @@ final class InvalidUsesBothYamlStrategiesTest {
   @Test
   void it_fails_when_using_both_strategies(@TempDir Path tmpDir) {
     SemgrepModule module =
-        new SemgrepModule(tmpDir, List.of(InvalidUsesBothYamlStrategies.class), List.of());
+        new SemgrepModule(
+            tmpDir,
+            List.of("**"),
+            List.of(),
+            List.of(InvalidUsesBothYamlStrategies.class),
+            List.of());
     assertThrows(
         CreationException.class,
         () -> {

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/implicitbutmultiplerules/UsesImplicitButHasMultipleRulesTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/implicitbutmultiplerules/UsesImplicitButHasMultipleRulesTest.java
@@ -15,7 +15,12 @@ final class UsesImplicitButHasMultipleRulesTest {
   @Test
   void it_fails_when_implicit_rule_but_multiple_specified(@TempDir Path tmpDir) {
     SemgrepModule module =
-        new SemgrepModule(tmpDir, List.of(UsesImplicitButHasMultipleRules.class), List.of());
+        new SemgrepModule(
+            tmpDir,
+            List.of("**"),
+            List.of(),
+            List.of(UsesImplicitButHasMultipleRules.class),
+            List.of());
     assertThrows(CreationException.class, () -> Guice.createInjector(module));
   }
 }


### PR DESCRIPTION
When invoking Semgrep and PMD, scanners were scanning _all files_, even if codemods weren't being asked to scan _all_ files. This change gives all the providers all the "include/exclude" configuration so they can parameterize their scans accordingly.

For some context, this PR increases the speedup of some large projects from 10 minutes to 1 minute, when scanning one file.