### PR TITLE
Bump file cache size

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/FileCache.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/FileCache.java
@@ -19,7 +19,7 @@ public interface FileCache {
   void overrideEntry(Path path, String contents);
 
   static FileCache createDefault() {
-    return createDefault(5000);
+    return createDefault(10_000);
   }
 
   static FileCache createDefault(final int maxSize) {


### PR DESCRIPTION
Although we could always find projects that are bigger than whatever our cache size is, we have found that even the largest projects we're testing with fall under 10K.