### PR TITLE
Added limits useful for testing

### DIFF
--- a/core-codemods/src/test/java/io/codemodder/codemods/AddMissingI18nCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/AddMissingI18nCodemodTest.java
@@ -227,7 +227,7 @@ final class AddMissingI18nCodemodTest {
     assertThat("Only expecting 1 codemod per test", codemods.size(), equalTo(1));
     CodemodIdPair pair = codemods.get(0);
     CodemodExecutor executor =
-        CodemodExecutor.from(
+        CodemodExecutorFactory.from(
             repoRoot,
             IncludesExcludes.any(),
             pair,

--- a/core-codemods/src/test/java/io/codemodder/codemods/JSPScriptletXSSCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/JSPScriptletXSSCodemodTest.java
@@ -52,7 +52,7 @@ final class JSPScriptletXSSCodemodTest {
             List.of());
     CodemodIdPair codemod = codemodInvoker.getCodemods().get(0);
     CodemodExecutor executor =
-        CodemodExecutor.from(
+        CodemodExecutorFactory.from(
             tmpDir,
             IncludesExcludes.any(),
             codemod,

--- a/core-codemods/src/test/java/io/codemodder/codemods/VerbTamperingCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/VerbTamperingCodemodTest.java
@@ -62,7 +62,7 @@ final class VerbTamperingCodemodTest {
             List.of());
 
     CodemodExecutor executor =
-        CodemodExecutor.from(
+        CodemodExecutorFactory.from(
             tmpDir,
             IncludesExcludes.any(),
             loader.getCodemods().get(0),

--- a/framework/codemodder-base/src/main/java/io/codemodder/CodemodExecutor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodemodExecutor.java
@@ -1,7 +1,6 @@
 package io.codemodder;
 
 import io.codemodder.codetf.CodeTFResult;
-import io.codemodder.javaparser.CachingJavaParser;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -10,24 +9,4 @@ public interface CodemodExecutor {
 
   /** Execute the codemod on the given file paths. */
   CodeTFResult execute(List<Path> filePaths);
-
-  static CodemodExecutor from(
-      final Path projectDir,
-      final IncludesExcludes includesExcludes,
-      final CodemodIdPair codemod,
-      final List<ProjectProvider> projectProviders,
-      final List<CodeTFProvider> codetfProviders,
-      final FileCache fileCache,
-      final CachingJavaParser javaParser,
-      final EncodingDetector encodingDetector) {
-    return new DefaultCodemodExecutor(
-        projectDir,
-        includesExcludes,
-        codemod,
-        projectProviders,
-        codetfProviders,
-        fileCache,
-        javaParser,
-        encodingDetector);
-  }
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/CachingJavaParser.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/CachingJavaParser.java
@@ -2,7 +2,6 @@ package io.codemodder.javaparser;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
-import java.io.IOException;
 import java.nio.file.Path;
 
 /**
@@ -19,7 +18,6 @@ public interface CachingJavaParser {
    * @param file a Java file path
    * @param contents the contents of the file
    * @return a {@link CompilationUnit} for the given file
-   * @throws IOException if there is a file I/O error
    */
   CompilationUnit parseJavaFile(Path file, String contents);
 

--- a/framework/codemodder-base/src/test/java/io/codemodder/CodemodLoaderTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/CodemodLoaderTest.java
@@ -170,7 +170,9 @@ final class CodemodLoaderTest {
               List.of(),
               FileCache.createDefault(),
               CachingJavaParser.from(new JavaParser()),
-              EncodingDetector.create());
+              EncodingDetector.create(),
+              10_000_000,
+              10_000);
       executor.execute(List.of(file));
     }
 
@@ -305,7 +307,9 @@ final class CodemodLoaderTest {
               List.of(),
               FileCache.createDefault(),
               CachingJavaParser.from(new JavaParser()),
-              EncodingDetector.create());
+              EncodingDetector.create(),
+              10_000_000,
+              10_000);
       Path p = tmpDir.resolve("foo.txt");
       Files.writeString(p, "1\n2\n3");
       CodeTFResult result = executor.execute(List.of(p));

--- a/framework/codemodder-base/src/test/java/io/codemodder/CodemodLoaderTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/CodemodLoaderTest.java
@@ -171,8 +171,8 @@ final class CodemodLoaderTest {
               FileCache.createDefault(),
               CachingJavaParser.from(new JavaParser()),
               EncodingDetector.create(),
-              10_000_000,
-              10_000);
+              -1,
+              -1);
       executor.execute(List.of(file));
     }
 
@@ -308,8 +308,8 @@ final class CodemodLoaderTest {
               FileCache.createDefault(),
               CachingJavaParser.from(new JavaParser()),
               EncodingDetector.create(),
-              10_000_000,
-              10_000);
+              -1,
+              -1);
       Path p = tmpDir.resolve("foo.txt");
       Files.writeString(p, "1\n2\n3");
       CodeTFResult result = executor.execute(List.of(p));

--- a/framework/codemodder-base/src/test/java/io/codemodder/javaparser/DefaultCachingJavaParserTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/javaparser/DefaultCachingJavaParserTest.java
@@ -1,0 +1,48 @@
+package io.codemodder.javaparser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.javaparser.ast.CompilationUnit;
+import io.codemodder.SourceDirectory;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class DefaultCachingJavaParserTest {
+
+  private DefaultCachingJavaParser cache;
+  private Path javaFile;
+  private String javaCode;
+
+  @BeforeEach
+  void setup(@TempDir Path tmpDir) throws IOException {
+    this.javaFile = tmpDir.resolve("Foo.java").toAbsolutePath();
+    this.javaCode =
+        """
+                package com.acme.util;
+                public abstract class Foo {
+                    public String a, b, c;
+                }
+                """;
+    Files.writeString(javaFile, javaCode);
+    var srcDirs = List.of(SourceDirectory.createDefault(tmpDir, List.of(javaFile.toString())));
+    this.cache = new DefaultCachingJavaParser(JavaParserFactory.newFactory().create(srcDirs));
+  }
+
+  @Test
+  void it_caches() {
+    CompilationUnit cu = cache.parseJavaFile(javaFile, javaCode);
+    assertThat(cu).isNotNull();
+    assertThat(cu.getPackageDeclaration().orElseThrow().getNameAsString())
+        .isEqualTo("com.acme.util");
+
+    CompilationUnit cachedCu = cache.parseJavaFile(javaFile, "invalid java here");
+    assertThat(cachedCu).isSameAs(cu);
+    assertThat(cachedCu.getPackageDeclaration().orElseThrow().getNameAsString())
+        .isEqualTo("com.acme.util");
+  }
+}

--- a/framework/codemodder-testutils/src/main/java/io/codemodder/CodemodExecutorFactory.java
+++ b/framework/codemodder-testutils/src/main/java/io/codemodder/CodemodExecutorFactory.java
@@ -1,0 +1,31 @@
+package io.codemodder;
+
+import io.codemodder.javaparser.CachingJavaParser;
+import java.nio.file.Path;
+import java.util.List;
+
+/** A utility for generating a {@link CodemodExecutor} for testing, with some sane defaults. */
+public interface CodemodExecutorFactory {
+
+  static CodemodExecutor from(
+      final Path projectDir,
+      final IncludesExcludes includesExcludes,
+      final CodemodIdPair codemod,
+      final List<ProjectProvider> projectProviders,
+      final List<CodeTFProvider> codetfProviders,
+      final FileCache fileCache,
+      final CachingJavaParser javaParser,
+      final EncodingDetector encodingDetector) {
+    return new DefaultCodemodExecutor(
+        projectDir,
+        includesExcludes,
+        codemod,
+        projectProviders,
+        codetfProviders,
+        fileCache,
+        javaParser,
+        encodingDetector,
+        10_000_000,
+        10_000);
+  }
+}

--- a/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/CodemodTestMixin.java
+++ b/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/CodemodTestMixin.java
@@ -120,7 +120,7 @@ public interface CodemodTestMixin {
     JavaParserFactory factory = JavaParserFactory.newFactory();
     SourceDirectory dir = SourceDirectory.createDefault(tmpDir, List.of(pathToJavaFile.toString()));
     CodemodExecutor executor =
-        CodemodExecutor.from(
+        CodemodExecutorFactory.from(
             tmpDir,
             IncludesExcludes.any(),
             codemod,
@@ -184,7 +184,7 @@ public interface CodemodTestMixin {
             List.of());
     CodemodIdPair codemod2 = loader2.getCodemods().get(0);
     CodemodExecutor executor2 =
-        CodemodExecutor.from(
+        CodemodExecutorFactory.from(
             tmpDir,
             IncludesExcludes.any(),
             codemod2,

--- a/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/RawFileCodemodTest.java
+++ b/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/RawFileCodemodTest.java
@@ -71,7 +71,7 @@ public interface RawFileCodemodTest {
 
     CodemodIdPair pair = codemods.get(0);
     CodemodExecutor executor =
-        CodemodExecutor.from(
+        CodemodExecutorFactory.from(
             tmpDir,
             IncludesExcludes.any(),
             pair,

--- a/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdRuleSarif.java
+++ b/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdRuleSarif.java
@@ -4,12 +4,7 @@ import com.contrastsecurity.sarif.Region;
 import com.contrastsecurity.sarif.Result;
 import com.contrastsecurity.sarif.SarifSchema210;
 import io.codemodder.RuleSarif;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -18,12 +13,15 @@ final class PmdRuleSarif implements RuleSarif {
 
   private final SarifSchema210 sarif;
   private final String ruleId;
-  private final Map<Path, List<Result>> resultsCache;
+  private final Map<String, List<Result>> resultsByFile;
 
-  public PmdRuleSarif(final String ruleId, final SarifSchema210 sarif) {
+  PmdRuleSarif(
+      final String ruleId,
+      final SarifSchema210 sarif,
+      final Map<String, List<Result>> resultsByFile) {
     this.ruleId = Objects.requireNonNull(ruleId);
     this.sarif = Objects.requireNonNull(sarif);
-    this.resultsCache = new HashMap<>();
+    this.resultsByFile = Objects.requireNonNull(resultsByFile);
   }
 
   @Override
@@ -34,31 +32,9 @@ final class PmdRuleSarif implements RuleSarif {
   }
 
   @Override
-  public List<Result> getResultsByPath(Path path) {
-    if (resultsCache.containsKey(path)) {
-      return resultsCache.get(path);
-    }
-    List<Result> results =
-        sarif.getRuns().get(0).getResults().stream()
-            .filter(result -> ruleId.endsWith("/" + result.getRuleId()))
-            .filter(
-                result -> {
-                  String uri =
-                      result
-                          .getLocations()
-                          .get(0)
-                          .getPhysicalLocation()
-                          .getArtifactLocation()
-                          .getUri();
-                  try {
-                    return Files.isSameFile(path, Path.of(new URI(uri)));
-                  } catch (IOException | URISyntaxException e) { // this should never happen
-                    throw new IllegalStateException(e);
-                  }
-                })
-            .toList();
-    resultsCache.put(path, results);
-    return results;
+  public List<Result> getResultsByPath(final Path path) {
+    String absolutePath = path.toAbsolutePath().toString();
+    return resultsByFile.getOrDefault(absolutePath, List.of());
   }
 
   @Override


### PR DESCRIPTION
This PR adds the ability to restrict the amount of work done in a codemodder scan. I wish I had these flags useful for testing several times before now, and I think eventually they may be useful for downstream consumers to "limit the work" that a codemodder run can do. 

Hopefully, we'll be following this PR quickly with work to make these parameters obsolete (because removing `CompilationUnit` caching and I/O parallelization will fix everything), but I like having them around in case we ever run into situations where we'd like to performance test locally.