### PR TITLE
Allow codemod prioritization

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/InputResourceLeakCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/InputResourceLeakCodemod.java
@@ -13,7 +13,8 @@ import javax.inject.Inject;
  */
 @Codemod(
     id = "codeql:java/input-resource-leak",
-    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
 public final class InputResourceLeakCodemod extends SarifPluginJavaParserChanger<Expression> {
 
   @Inject

--- a/core-codemods/src/main/java/io/codemodder/codemods/InsecureCookieCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/InsecureCookieCodemod.java
@@ -8,19 +8,17 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
-import io.codemodder.Codemod;
-import io.codemodder.CodemodInvocationContext;
-import io.codemodder.RegionExtractor;
-import io.codemodder.ReviewGuidance;
-import io.codemodder.RuleSarif;
-import io.codemodder.SarifPluginJavaParserChanger;
+import io.codemodder.*;
 import io.codemodder.ast.ASTTransforms;
 import io.codemodder.providers.sarif.codeql.ProvidedCodeQLScan;
 import java.util.Optional;
 import javax.inject.Inject;
 
 /** Fixes issues reported under the id "java/insecure-cookie". */
-@Codemod(id = "codeql:java/insecure-cookie", reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
+@Codemod(
+    id = "codeql:java/insecure-cookie",
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
 public class InsecureCookieCodemod extends SarifPluginJavaParserChanger<MethodCallExpr> {
 
   @Inject

--- a/core-codemods/src/main/java/io/codemodder/codemods/JDBCResourceLeakCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/JDBCResourceLeakCodemod.java
@@ -3,12 +3,7 @@ package io.codemodder.codemods;
 import com.contrastsecurity.sarif.Result;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
-import io.codemodder.Codemod;
-import io.codemodder.CodemodInvocationContext;
-import io.codemodder.RegionExtractor;
-import io.codemodder.ReviewGuidance;
-import io.codemodder.RuleSarif;
-import io.codemodder.SarifPluginJavaParserChanger;
+import io.codemodder.*;
 import io.codemodder.providers.sarif.codeql.ProvidedCodeQLScan;
 import javax.inject.Inject;
 
@@ -18,7 +13,8 @@ import javax.inject.Inject;
  */
 @Codemod(
     id = "codeql:java/database-resource-leak",
-    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
 public final class JDBCResourceLeakCodemod extends SarifPluginJavaParserChanger<MethodCallExpr> {
 
   @Inject

--- a/core-codemods/src/main/java/io/codemodder/codemods/JEXLInjectionCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/JEXLInjectionCodemod.java
@@ -32,7 +32,8 @@ import org.apache.commons.jexl3.JexlExpression;
  */
 @Codemod(
     id = "codeql:java/jexl-expression-injection",
-    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
 public final class JEXLInjectionCodemod extends SarifPluginJavaParserChanger<Expression> {
 
   @Inject

--- a/core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java
@@ -26,7 +26,8 @@ import org.xml.sax.SAXException;
 /** Fixes issues reported under the id "java/maven/non-https-url". */
 @Codemod(
     id = "codeql:java/maven/non-https-url",
-    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
 public final class MavenSecureURLCodemod extends SarifPluginRawFileChanger {
 
   private final XPathStreamProcessor processor;

--- a/core-codemods/src/main/java/io/codemodder/codemods/OutputResourceLeakCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/OutputResourceLeakCodemod.java
@@ -13,7 +13,8 @@ import javax.inject.Inject;
  */
 @Codemod(
     id = "codeql:java/output-resource-leak",
-    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
 public final class OutputResourceLeakCodemod extends SarifPluginJavaParserChanger<Expression> {
 
   @Inject

--- a/core-codemods/src/main/java/io/codemodder/codemods/StackTraceExposureCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/StackTraceExposureCodemod.java
@@ -13,7 +13,8 @@ import javax.inject.Inject;
 /** Fixes issues reported under the id "java/stack-trace-exposure" */
 @Codemod(
     id = "codeql:java/stack-trace-exposure",
-    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
 public class StackTraceExposureCodemod extends SarifPluginJavaParserChanger<Expression> {
 
   @Inject

--- a/core-codemods/src/main/java/io/codemodder/codemods/UnverifiedJwtCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/UnverifiedJwtCodemod.java
@@ -5,12 +5,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
-import io.codemodder.Codemod;
-import io.codemodder.CodemodInvocationContext;
-import io.codemodder.RegionExtractor;
-import io.codemodder.ReviewGuidance;
-import io.codemodder.RuleSarif;
-import io.codemodder.SarifPluginJavaParserChanger;
+import io.codemodder.*;
 import io.codemodder.ast.ASTTransforms;
 import io.codemodder.ast.ASTs;
 import io.codemodder.ast.LocalVariableDeclaration;
@@ -20,7 +15,8 @@ import javax.inject.Inject;
 /** Fixes issues reported under the id "missing-jwt-signature-check". */
 @Codemod(
     id = "codeql:java/missing-jwt-signature-check",
-    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
 public class UnverifiedJwtCodemod extends SarifPluginJavaParserChanger<Expression> {
 
   @Inject

--- a/framework/codemodder-base/src/main/java/io/codemodder/Codemod.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/Codemod.java
@@ -32,4 +32,7 @@ public @interface Codemod {
    * @return review guidance
    */
   ReviewGuidance reviewGuidance();
+
+  /** How important it is that this codemod execute sooner in the list of codemods being run. */
+  CodemodExecutionPriority executionPriority() default CodemodExecutionPriority.NORMAL;
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/CodemodExecutionPriority.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodemodExecutionPriority.java
@@ -1,0 +1,25 @@
+package io.codemodder;
+
+import java.util.Comparator;
+
+/**
+ * A description of how important it is that a codemod execute in the list of codemods being run.
+ */
+public enum CodemodExecutionPriority {
+  LOW(0),
+  NORMAL(1),
+  HIGH(2);
+
+  private final int level;
+
+  CodemodExecutionPriority(final int level) {
+    this.level = level;
+  }
+
+  /**
+   * Expose a package-protected comparator so nobody else needs to worry about how our priority is
+   * actually established.
+   */
+  static final Comparator<CodemodExecutionPriority> priorityOrderComparator =
+      (p1, p2) -> Integer.compare(p2.level, p1.level);
+}


### PR DESCRIPTION
In the effort towards removing caching of JavaParser templates, which had sturdy line information, we want to allow certain codemods (primarily SARIF-driven codemods, to start) to declare a higher priority. Because they can't re-generate their SARIF easily, they should get "first shot" at changing code before others that can generate their own results, can.