### PR TITLE
Run PMD lazily

### DIFF
--- a/core-codemods/src/intTest/java/io/codemodder/integration/WebGoat822Test.java
+++ b/core-codemods/src/intTest/java/io/codemodder/integration/WebGoat822Test.java
@@ -95,7 +95,7 @@ final class WebGoat822Test extends GitRepositoryTest {
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
 
-    assertThat(fileChanges.size(), is(50));
+    assertThat(fileChanges.size(), is(52));
 
     // we only inject into a couple files
     verifyStandardCodemodResults(fileChanges);
@@ -133,7 +133,7 @@ final class WebGoat822Test extends GitRepositoryTest {
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
 
-    assertThat(fileChanges.size(), is(53));
+    assertThat(fileChanges.size(), is(55));
 
     verifyStandardCodemodResults(fileChanges);
 

--- a/framework/codemodder-base/src/main/java/io/codemodder/LazyLoadingRuleSarif.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/LazyLoadingRuleSarif.java
@@ -1,0 +1,59 @@
+package io.codemodder;
+
+import com.contrastsecurity.sarif.Region;
+import com.contrastsecurity.sarif.Result;
+import com.contrastsecurity.sarif.SarifSchema210;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import javax.inject.Provider;
+
+public class LazyLoadingRuleSarif implements RuleSarif {
+
+  private RuleSarif ruleSarif;
+  private final Provider<RuleSarif> ruleSarifProvider;
+
+  public LazyLoadingRuleSarif(final Provider<RuleSarif> ruleSarifProvider) {
+    this.ruleSarif = null; // not initialized
+    this.ruleSarifProvider = Objects.requireNonNull(ruleSarifProvider);
+  }
+
+  @Override
+  public List<Region> getRegionsFromResultsByRule(final Path path) {
+    checkInitialized();
+    return ruleSarif.getRegionsFromResultsByRule(path);
+  }
+
+  private void checkInitialized() {
+    if (ruleSarif == null) {
+      ruleSarif = ruleSarifProvider.get();
+      if (ruleSarif == null) {
+        throw new IllegalStateException("SARIF must be provided");
+      }
+    }
+  }
+
+  @Override
+  public List<Result> getResultsByPath(final Path path) {
+    checkInitialized();
+    return ruleSarif.getResultsByPath(path);
+  }
+
+  @Override
+  public SarifSchema210 rawDocument() {
+    checkInitialized();
+    return ruleSarif.rawDocument();
+  }
+
+  @Override
+  public String getRule() {
+    checkInitialized();
+    return ruleSarif.getRule();
+  }
+
+  @Override
+  public String getDriver() {
+    checkInitialized();
+    return ruleSarif.getDriver();
+  }
+}

--- a/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdModule.java
+++ b/plugins/codemodder-plugin-pmd/src/main/java/io/codemodder/providers/sarif/pmd/PmdModule.java
@@ -4,6 +4,7 @@ import com.contrastsecurity.sarif.Result;
 import com.contrastsecurity.sarif.SarifSchema210;
 import com.google.inject.AbstractModule;
 import io.codemodder.CodeChanger;
+import io.codemodder.LazyLoadingRuleSarif;
 import io.codemodder.RuleSarif;
 import io.github.classgraph.*;
 import java.lang.reflect.Executable;
@@ -11,7 +12,6 @@ import java.lang.reflect.Parameter;
 import java.nio.file.*;
 import java.util.*;
 import javax.inject.Inject;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,10 +35,6 @@ public final class PmdModule extends AbstractModule {
 
   @Override
   protected void configure() {
-
-    // find all @PmdScan annotations in their parameters and batch them up for running
-    List<Pair<String, PmdScan>> toBind = new ArrayList<>();
-
     Set<String> packagesScanned = new HashSet<>();
 
     for (Class<? extends CodeChanger> codemodType : codemodTypes) {
@@ -77,50 +73,46 @@ public final class PmdModule extends AbstractModule {
               }
 
               PmdScan pmdScan = param.getAnnotation(PmdScan.class);
-              String ruleId = pmdScan.ruleId();
-              Pair<String, PmdScan> rulePair = Pair.of(ruleId, pmdScan);
-              toBind.add(rulePair);
+              final String ruleId = pmdScan.ruleId();
+
+              RuleSarif sarif =
+                  new LazyLoadingRuleSarif(
+                      () -> {
+                        LOG.trace("Running pmd for rule: {}", ruleId);
+                        SarifSchema210 rawSarifFromRun =
+                            pmdRunner.run(List.of(ruleId), codeDirectory, includedFiles);
+                        LOG.trace("Finished running pmd for rule: {}", ruleId);
+                        int lastSlash = ruleId.lastIndexOf("/");
+                        if (lastSlash == -1) {
+                          throw new IllegalStateException("unexpected rule id: " + ruleId);
+                        }
+                        String trimmedRuleId = ruleId.substring(lastSlash + 1);
+                        Map<String, List<Result>> resultsByFile = new HashMap<>();
+                        List<Result> allResults = rawSarifFromRun.getRuns().get(0).getResults();
+                        for (Result result : allResults) {
+                          String filePath =
+                              result
+                                  .getLocations()
+                                  .get(0)
+                                  .getPhysicalLocation()
+                                  .getArtifactLocation()
+                                  .getUri();
+                          String normalizedFilePath =
+                              filePath.startsWith("file://") ? filePath.substring(7) : filePath;
+                          List<Result> resultsForFile =
+                              resultsByFile.computeIfAbsent(
+                                  normalizedFilePath, k -> new ArrayList<>());
+                          resultsForFile.add(result);
+                        }
+                        return new PmdRuleSarif(trimmedRuleId, rawSarifFromRun, resultsByFile);
+                      });
+
+              this.bind(RuleSarif.class).annotatedWith(pmdScan).toInstance(sarif);
             });
 
         LOG.trace("Finished scanning codemod package: {}", packageName);
         packagesScanned.add(packageName);
       }
-    }
-
-    if (toBind.isEmpty()) {
-      // no reason to run pmd if there are no annotations
-      return;
-    }
-
-    List<String> rules = toBind.stream().map(Pair::getLeft).toList();
-    SarifSchema210 sarif = pmdRunner.run(rules, codeDirectory, includedFiles);
-
-    // bind the SARIF results to individual codemods
-    Map<String, Map<String, List<Result>>> resultsByRule = new HashMap<>();
-    List<Result> allResults = sarif.getRuns().get(0).getResults();
-    for (Result result : allResults) {
-      String ruleId = result.getRuleId();
-      Map<String, List<Result>> resultsByFile =
-          resultsByRule.computeIfAbsent(ruleId, k -> new HashMap<>());
-      String filePath =
-          result.getLocations().get(0).getPhysicalLocation().getArtifactLocation().getUri();
-      String normalizedFilePath = filePath.startsWith("file://") ? filePath.substring(7) : filePath;
-      List<Result> resultsForFile =
-          resultsByFile.computeIfAbsent(normalizedFilePath, k -> new ArrayList<>());
-      resultsForFile.add(result);
-    }
-
-    for (Pair<String, PmdScan> bindingPair : toBind) {
-      PmdScan sarifAnnotation = bindingPair.getRight();
-      String pmdRuleId = bindingPair.getLeft();
-      int lastSlash = pmdRuleId.lastIndexOf("/");
-      if (lastSlash == -1) {
-        throw new IllegalStateException("unexpected rule id: " + pmdRuleId);
-      }
-      pmdRuleId = pmdRuleId.substring(lastSlash + 1);
-      PmdRuleSarif pmdSarif =
-          new PmdRuleSarif(pmdRuleId, sarif, resultsByRule.getOrDefault(pmdRuleId, Map.of()));
-      bind(RuleSarif.class).annotatedWith(sarifAnnotation).toInstance(pmdSarif);
     }
   }
 


### PR DESCRIPTION
This change moves execution of PMD until the SARIF needs to be inspected. This will allow on-demand execution of PMD so the most up-to-date line information can be captured.