### PR TITLE
Added short-circuiting logic for codemods

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/CodeChanger.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodeChanger.java
@@ -21,4 +21,9 @@ public interface CodeChanger {
 
   /** A description of an individual change made by this codemod. */
   String getIndividualChangeDescription(final Path filePath, final CodemodChange change);
+
+  /**
+   * A lifecycle event that is called before any files are processed. This is a good place to short circuit if you don't have the necessary resources (e.g., SARIF).
+   */
+  default boolean shouldRun() { return true; }
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/CodeChanger.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodeChanger.java
@@ -23,7 +23,10 @@ public interface CodeChanger {
   String getIndividualChangeDescription(final Path filePath, final CodemodChange change);
 
   /**
-   * A lifecycle event that is called before any files are processed. This is a good place to short circuit if you don't have the necessary resources (e.g., SARIF).
+   * A lifecycle event that is called before any files are processed. This is a good place to short
+   * circuit if you don't have the necessary resources (e.g., SARIF).
    */
-  default boolean shouldRun() { return true; }
+  default boolean shouldRun() {
+    return true;
+  }
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/RawFileCodemodRunner.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/RawFileCodemodRunner.java
@@ -25,7 +25,7 @@ final class RawFileCodemodRunner implements CodemodRunner {
 
   @Override
   public List<CodemodChange> run(final CodemodInvocationContext context) throws IOException {
-    if(!changer.shouldRun()) {
+    if (!changer.shouldRun()) {
       return List.of();
     }
     return changer.visitFile(context);

--- a/framework/codemodder-base/src/main/java/io/codemodder/RawFileCodemodRunner.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/RawFileCodemodRunner.java
@@ -25,6 +25,9 @@ final class RawFileCodemodRunner implements CodemodRunner {
 
   @Override
   public List<CodemodChange> run(final CodemodInvocationContext context) throws IOException {
+    if(!changer.shouldRun()) {
+      return List.of();
+    }
     return changer.visitFile(context);
   }
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/RuleSarif.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/RuleSarif.java
@@ -41,12 +41,12 @@ public interface RuleSarif {
   final class EmptyRuleSarif implements RuleSarif {
 
     @Override
-    public List<Region> getRegionsFromResultsByRule(Path path) {
+    public List<Region> getRegionsFromResultsByRule(final Path path) {
       return List.of();
     }
 
     @Override
-    public List<Result> getResultsByPath(Path path) {
+    public List<Result> getResultsByPath(final Path path) {
       return List.of();
     }
 

--- a/framework/codemodder-base/src/main/java/io/codemodder/SarifPluginJavaParserChanger.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/SarifPluginJavaParserChanger.java
@@ -2,6 +2,7 @@ package io.codemodder;
 
 import com.contrastsecurity.sarif.Region;
 import com.contrastsecurity.sarif.Result;
+import com.contrastsecurity.sarif.Run;
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
@@ -130,6 +131,12 @@ public abstract class SarifPluginJavaParserChanger<T extends Node> extends JavaP
       }
     }
     return codemodChanges;
+  }
+
+  @Override
+  public boolean shouldRun() {
+    List<Run> runs = sarif.rawDocument().getRuns();
+    return runs != null && runs.size() > 0 && !runs.get(0).getResults().isEmpty();
   }
 
   /**

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserCodemodRunner.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserCodemodRunner.java
@@ -41,7 +41,7 @@ public final class JavaParserCodemodRunner implements CodemodRunner {
 
   @Override
   public List<CodemodChange> run(final CodemodInvocationContext context) throws IOException {
-    if(!javaParserChanger.shouldRun()) {
+    if (!javaParserChanger.shouldRun()) {
       return List.of();
     }
     Path file = context.path();
@@ -55,5 +55,4 @@ public final class JavaParserCodemodRunner implements CodemodRunner {
     }
     return changes;
   }
-
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserCodemodRunner.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserCodemodRunner.java
@@ -41,6 +41,9 @@ public final class JavaParserCodemodRunner implements CodemodRunner {
 
   @Override
   public List<CodemodChange> run(final CodemodInvocationContext context) throws IOException {
+    if(!javaParserChanger.shouldRun()) {
+      return List.of();
+    }
     Path file = context.path();
     CompilationUnit cu = parser.parseJavaFile(file);
     List<CodemodChange> changes = javaParserChanger.visit(context, cu);
@@ -52,4 +55,5 @@ public final class JavaParserCodemodRunner implements CodemodRunner {
     }
     return changes;
   }
+
 }


### PR DESCRIPTION
Added a hook for `CodemodRunner` to short-circuit running a codemod if the codemod _knows_ it doesn't have the pre-requisites to make any changes. For example, if a CodeQL scan is not provided via SARIF inputs on the command line, then there is no way a CodeQL-based codemod will make any changes -- so we shouldn't even try.

This helps performance on all projects, but is game-breaking on extremely big projects. For instance, on the `Grasscutter` repo, our pre-PR testing shows it was on track for 3+ hours. After this change, execution finishes in 25 minutes.