### PR TITLE
Catch and suppress noisy JavaParser runtime errors 

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizer.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizer.java
@@ -69,7 +69,7 @@ final class SQLParameterizer {
                         try {
                           String resolvedType = s.calculateResolvedType().describe();
                           return "java.sql.Statement".equals(resolvedType);
-                        } catch (IllegalArgumentException | UnsolvedSymbolException e) {
+                        } catch (IllegalArgumentException | RuntimeException | UnsolvedSymbolException e) {
                           return false;
                         }
                       })
@@ -84,7 +84,7 @@ final class SQLParameterizer {
       return rule1.test(methodCallExpr);
 
       // Thrown by the JavaParser Symbol Solver when it can't resolve types
-    } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
+    } catch (UnsolvedSymbolException | RuntimeException | UnsupportedOperationException e) {
       return false;
     }
   }
@@ -94,7 +94,7 @@ final class SQLParameterizer {
         e -> {
           try {
             return "java.sql.Connection".equals(e.calculateResolvedType().describe());
-          } catch (IllegalArgumentException | UnsolvedSymbolException ex) {
+          } catch (IllegalArgumentException | RuntimeException | UnsolvedSymbolException ex) {
             return false;
           }
         };

--- a/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizer.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizer.java
@@ -15,7 +15,6 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
-import com.github.javaparser.resolution.UnsolvedSymbolException;
 import io.codemodder.Either;
 import io.codemodder.ast.ASTTransforms;
 import io.codemodder.ast.ASTs;
@@ -69,7 +68,7 @@ final class SQLParameterizer {
                         try {
                           String resolvedType = s.calculateResolvedType().describe();
                           return "java.sql.Statement".equals(resolvedType);
-                        } catch (IllegalArgumentException | RuntimeException | UnsolvedSymbolException e) {
+                        } catch (RuntimeException e) {
                           return false;
                         }
                       })
@@ -84,7 +83,7 @@ final class SQLParameterizer {
       return rule1.test(methodCallExpr);
 
       // Thrown by the JavaParser Symbol Solver when it can't resolve types
-    } catch (UnsolvedSymbolException | RuntimeException | UnsupportedOperationException e) {
+    } catch (RuntimeException e) {
       return false;
     }
   }
@@ -94,7 +93,7 @@ final class SQLParameterizer {
         e -> {
           try {
             return "java.sql.Connection".equals(e.calculateResolvedType().describe());
-          } catch (IllegalArgumentException | RuntimeException | UnsolvedSymbolException ex) {
+          } catch (RuntimeException ex) {
             return false;
           }
         };


### PR DESCRIPTION
A noisy error was reported on user code when resolving symbols. We can't do anything about these errors, so we suppress and move on.