### PR TITLE
Fix POMScanner details compared to kotlin version

### DIFF
--- a/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/operator/POMScanner.java
+++ b/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/operator/POMScanner.java
@@ -3,6 +3,7 @@ package io.codemodder.plugins.maven.operator;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -110,6 +111,8 @@ public class POMScanner {
       }
     }
 
+    lastFile = originalFile;
+
     Set<String> prevPaths = new HashSet<>();
     POMDocument prevPOMDocument = pomFile;
 
@@ -134,9 +137,9 @@ public class POMScanner {
         prevPaths.add(relativePath);
       }
 
-      Path newPath = POMScanner.resolvePath(originalFile, relativePath);
+      Path newPath = POMScanner.resolvePath(lastFile, relativePath);
 
-      if (!newPath.toFile().exists()) {
+      if (Files.notExists(newPath)) {
         LOGGER.warn("new path does not exist: " + newPath);
         break;
       }


### PR DESCRIPTION
While I was debugging some stuff related to the exception below and comparing the java code against kotlin code, I found 2 details in the POMScanner:

1. I didn't use the mutable variable `lastFile`as in [kotlin code](https://github.com/pixee/pom-operator/blob/8e13abe14705a024791d8d9e1f0b554257e4cd2d/src/main/java/io/github/pixee/maven/operator/POMScanner.kt#L109)

2. Use java.nio.file.Files::notExists as in [kotlin code ](https://github.com/pixee/pom-operator/blob/8e13abe14705a024791d8d9e1f0b554257e4cd2d/src/main/java/io/github/pixee/maven/operator/POMScanner.kt#L111)

```
Oops: 
org.apache.maven.model.building.ModelBuildingException: 1 problem was encountered while building the effective model for io.trino:trino-client:430-SNAPSHOT
[FATAL] Non-resolvable parent POM for io.trino:trino-root:430-SNAPSHOT: Could not find artifact io.airlift:airbase:pom:147 and 'parent.relativePath' points at wrong local POM @ io.trino:trino-root:430-SNAPSHOT, /var/folders/sz/_rt55vg16m30f7v4228lwh4m0000gn/T/codemodder-project7214933722460326167/pom.xml

        at org.apache.maven.model.building.DefaultModelProblemCollector.newModelBuildingException(DefaultModelProblemCollector.java:197)
        at org.apache.maven.model.building.DefaultModelBuilder.readParentExternally(DefaultModelBuilder.java:1180)
        at org.apache.maven.model.building.DefaultModelBuilder.readParent(DefaultModelBuilder.java:916)
        at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:361)
        at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:267)
        at io.codemodder.plugins.maven.operator.EmbedderFacade.invokeEmbedder(EmbedderFacade.java:108)
        at io.codemodder.plugins.maven.operator.QueryByResolver.execute(QueryByResolver.java:53)
        at io.codemodder.plugins.maven.operator.CommandChain.execute(CommandChain.java:51)
        at io.codemodder.plugins.maven.operator.POMOperator.executeChain(POMOperator.java:184)
        at io.codemodder.plugins.maven.operator.POMOperator.queryDependency(POMOperator.java:128)
        at io.codemodder.plugins.maven.operator.POMOperator.queryDependency(POMOperator.java:38)
        at io.codemodder.plugins.maven.MavenProvider.getDependenciesFrom(MavenProvider.java:365)
        at io.codemodder.plugins.maven.MavenProvider.updateDependenciesInternal(MavenProvider.java:183)
        at io.codemodder.plugins.maven.MavenProvider.updateDependencies(MavenProvider.java:156)
        at io.codemodder.DefaultCodemodExecutor.addPackages(DefaultCodemodExecutor.java:203)
        at io.codemodder.DefaultCodemodExecutor.execute(DefaultCodemodExecutor.java:105)
        at io.codemodder.CLI.call(CLI.java:379)
        at io.codemodder.CLI.call(CLI.java:43)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
        at picocli.CommandLine.execute(CommandLine.java:2170)
        at io.codemodder.Runner.run(Runner.java:32)
        at io.codemodder.Runner.run(Runner.java:39)
        at io.codemodder.codemods.DefaultCodemods.main(DefaultCodemods.java:61)
```

