### PR TITLE
Add parallelization

### DIFF
--- a/core-codemods/src/test/java/io/codemodder/codemods/AddMissingI18nCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/AddMissingI18nCodemodTest.java
@@ -234,7 +234,7 @@ final class AddMissingI18nCodemodTest {
             List.of(),
             List.of(),
             FileCache.createDefault(),
-            JavaParserFacade.from(new JavaParser()),
+            JavaParserFacade.from(JavaParser::new),
             EncodingDetector.create());
     return executor.execute(
         List.of(

--- a/core-codemods/src/test/java/io/codemodder/codemods/JSPScriptletXSSCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/JSPScriptletXSSCodemodTest.java
@@ -59,7 +59,7 @@ final class JSPScriptletXSSCodemodTest {
             List.of(),
             List.of(),
             FileCache.createDefault(),
-            JavaParserFacade.from(new JavaParser()),
+            JavaParserFacade.from(JavaParser::new),
             EncodingDetector.create());
     CodeTFResult result = executor.execute(List.of(jsp));
 

--- a/core-codemods/src/test/java/io/codemodder/codemods/VerbTamperingCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/VerbTamperingCodemodTest.java
@@ -69,7 +69,7 @@ final class VerbTamperingCodemodTest {
             List.of(),
             List.of(),
             FileCache.createDefault(),
-            JavaParserFacade.from(new JavaParser()),
+            JavaParserFacade.from(JavaParser::new),
             EncodingDetector.create());
     CodeTFResult result = executor.execute(List.of(webxml));
     assertThat(result.getChangeset().isEmpty(), is(!expectChange));

--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -29,6 +29,7 @@ import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.inject.Provider;
 import net.logstash.logback.encoder.LogstashEncoder;
 import net.logstash.logback.fieldnames.LogstashCommonFieldNames;
 import net.logstash.logback.fieldnames.LogstashFieldNames;
@@ -373,8 +374,15 @@ final class CLI implements Callable<Integer> {
        * is what allows our codemods to act on SARIF-providing tools data accurately over multiple codemods.
        */
       logEnteringPhase(Logs.ExecutionPhase.SCANNING);
-      JavaParser javaParser = javaParserFactory.create(sourceDirectories);
-      JavaParserFacade javaParserFacade = JavaParserFacade.from(javaParser);
+      Provider<JavaParser> javaParserProvider =
+          () -> {
+            try {
+              return javaParserFactory.create(sourceDirectories);
+            } catch (IOException e) {
+              throw new UncheckedIOException(e);
+            }
+          };
+      JavaParserFacade javaParserFacade = JavaParserFacade.from(javaParserProvider);
       int maxFileCacheSize = 10_000;
       FileCache fileCache = FileCache.createDefault(maxFileCacheSize);
 

--- a/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
@@ -100,7 +100,10 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
             .limit(maxFiles != -1 ? maxFiles : Long.MAX_VALUE)
             .toList();
 
-    List<CodeTFChangesetEntry> changeset = Collections.synchronizedList(new ArrayList<>());
+    /*
+     * The changeset doesn't need to be thread-safe because it's only added to within a synchronized block.
+     */
+    List<CodeTFChangesetEntry> changeset = new ArrayList<>();
 
     int threadPoolSize = threadCountSelector.count();
     log.debug("analysis thread pool size: {}", threadPoolSize);

--- a/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
@@ -106,7 +106,6 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
     List<CodeTFChangesetEntry> changeset = new ArrayList<>();
 
     int threadPoolSize = threadCountSelector.count();
-    log.debug("analysis thread pool size: {}", threadPoolSize);
     ExecutorService executor = Executors.newFixedThreadPool(threadPoolSize);
     CompletionService<String> service = new ExecutorCompletionService<>(executor);
 

--- a/framework/codemodder-base/src/main/java/io/codemodder/FileCache.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/FileCache.java
@@ -18,6 +18,9 @@ public interface FileCache {
   /** Put the string contents of a file into the cache. */
   void overrideEntry(Path path, String contents);
 
+  /** Remove the string contents of a file from the cache if it exists. */
+  void removeEntry(final Path resolve);
+
   static FileCache createDefault() {
     return createDefault(10_000);
   }
@@ -44,6 +47,11 @@ public interface FileCache {
           throw new IllegalArgumentException("cache entry must be for an existing key");
         }
         fileCache.put(path, contents);
+      }
+
+      @Override
+      public void removeEntry(final Path path) {
+        fileCache.remove(path);
       }
     };
   }

--- a/framework/codemodder-base/src/main/java/io/codemodder/ThreadCountSelector.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/ThreadCountSelector.java
@@ -1,0 +1,9 @@
+package io.codemodder;
+
+/** Provides a way to select the best number of threads to use for heavy file I/O. */
+@FunctionalInterface
+interface ThreadCountSelector {
+
+  /** Return the number of threads to use for heavy file I/O. */
+  int count();
+}

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/DefaultJavaParserFacade.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/DefaultJavaParserFacade.java
@@ -12,7 +12,7 @@ import javax.inject.Provider;
 final class DefaultJavaParserFacade implements JavaParserFacade {
 
   private final Provider<JavaParser> parserProvider;
-  private ThreadLocal<JavaParser> javaParserRef;
+  private final ThreadLocal<JavaParser> javaParserRef;
 
   DefaultJavaParserFacade(final Provider<JavaParser> parserProvider) {
     this.parserProvider = Objects.requireNonNull(parserProvider);

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserFacade.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserFacade.java
@@ -4,6 +4,7 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import java.io.IOException;
 import java.nio.file.Path;
+import javax.inject.Provider;
 
 /**
  * Responsible for parsing Java files and maintaining the compilation units across different
@@ -23,7 +24,7 @@ public interface JavaParserFacade {
   CompilationUnit parseJavaFile(Path file) throws IOException;
 
   /** Return a simple implementation of the {@link JavaParserFacade} interface. */
-  static JavaParserFacade from(final JavaParser parser) {
+  static JavaParserFacade from(final Provider<JavaParser> parser) {
     return new DefaultJavaParserFacade(parser);
   }
 }

--- a/framework/codemodder-base/src/test/java/io/codemodder/CodemodLoaderTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/CodemodLoaderTest.java
@@ -224,7 +224,7 @@ final class CodemodLoaderTest {
                 List.of(),
                 List.of(),
                 FileCache.createDefault(),
-                JavaParserFacade.from(new JavaParser()),
+                JavaParserFacade.from(JavaParser::new),
                 EncodingDetector.create(),
                 -1,
                 -1);
@@ -362,7 +362,7 @@ final class CodemodLoaderTest {
               List.of(),
               List.of(),
               FileCache.createDefault(),
-              JavaParserFacade.from(new JavaParser()),
+              JavaParserFacade.from(JavaParser::new),
               EncodingDetector.create(),
               -1,
               -1);

--- a/framework/codemodder-base/src/test/java/io/codemodder/DefaultCodemodExecutorTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/DefaultCodemodExecutorTest.java
@@ -22,7 +22,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.random.RandomGenerator;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,7 +48,7 @@ final class DefaultCodemodExecutorTest {
     this.repoDir = tmpDir;
     beforeToAfterChanger = new BeforeToAfterChanger();
     beforeAfterCodemod = new CodemodIdPair("codemodder:java/id", beforeToAfterChanger);
-    javaParserFacade = JavaParserFacade.from(new JavaParser());
+    javaParserFacade = JavaParserFacade.from(JavaParser::new);
     encodingDetector = EncodingDetector.create();
     includesEverything = IncludesExcludes.any();
     fileCache = FileCache.createDefault();
@@ -308,7 +307,7 @@ final class DefaultCodemodExecutorTest {
               List.of(depsProvider),
               List.of(),
               fileCache,
-              JavaParserFacade.from(new JavaParser()),
+              JavaParserFacade.from(JavaParser::new),
               EncodingDetector.create(),
               -1,
               -1);
@@ -436,7 +435,7 @@ final class DefaultCodemodExecutorTest {
             List.of(badProvider),
             List.of(),
             fileCache,
-            JavaParserFacade.from(new JavaParser()),
+            JavaParserFacade.from(JavaParser::new),
             EncodingDetector.create(),
             -1,
             -1);
@@ -491,7 +490,7 @@ final class DefaultCodemodExecutorTest {
             List.of(skippingProvider),
             List.of(),
             fileCache,
-            JavaParserFacade.from(new JavaParser()),
+            JavaParserFacade.from(JavaParser::new),
             EncodingDetector.create(),
             -1,
             -1);
@@ -693,42 +692,6 @@ final class DefaultCodemodExecutorTest {
     public String getIndividualChangeDescription(final Path filePath, final CodemodChange change) {
       return "injects-dependency-2-change";
     }
-  }
-
-  @Test
-  void multithread() throws ExecutionException, InterruptedException {
-
-    ExecutorService pool = Executors.newFixedThreadPool(5);
-    CompletionService<String> service = new ExecutorCompletionService<String>(pool);
-
-    List<Future> futures = new ArrayList<>();
-    for (int i = 0; i < 20; i++) {
-      final int count = i;
-      Future<?> f =
-          pool.submit(
-              () -> {
-                int seconds = RandomGenerator.getDefault().nextInt(5);
-                System.out.println(
-                    "starting thread " + count + " and sleeping for " + seconds + " seconds");
-                try {
-                  Thread.sleep(seconds * 1000);
-                } catch (InterruptedException e) {
-                  throw new RuntimeException(e);
-                }
-              });
-      futures.add(f);
-    }
-
-    pool.shutdown();
-    boolean success = pool.awaitTermination(30, TimeUnit.SECONDS);
-    System.out.println("Success: " + success);
-
-    while (!pool.isTerminated()) {
-      final Future<String> future = service.take();
-      System.out.println("Finished: " + future.get());
-    }
-
-    System.out.println("Finished all ");
   }
 
   private static final DependencyGAV dependency1 =

--- a/framework/codemodder-base/src/test/java/io/codemodder/javaparser/DefaultJavaParserFacadeTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/javaparser/DefaultJavaParserFacadeTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.github.javaparser.ast.CompilationUnit;
 import io.codemodder.SourceDirectory;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -31,7 +32,15 @@ final class DefaultJavaParserFacadeTest {
                 """;
     Files.writeString(javaFile, javaCode);
     var srcDirs = List.of(SourceDirectory.createDefault(tmpDir, List.of(javaFile.toString())));
-    this.parser = new DefaultJavaParserFacade(JavaParserFactory.newFactory().create(srcDirs));
+    this.parser =
+        new DefaultJavaParserFacade(
+            () -> {
+              try {
+                return JavaParserFactory.newFactory().create(srcDirs);
+              } catch (IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            });
   }
 
   @Test

--- a/framework/codemodder-base/src/test/java/io/codemodder/javaparser/JavaParserCodemodRunnerTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/javaparser/JavaParserCodemodRunnerTest.java
@@ -73,7 +73,7 @@ final class JavaParserCodemodRunnerTest {
   void setup(@TempDir Path tmpDir) {
     this.runner =
         new JavaParserCodemodRunner(
-            JavaParserFacade.from(new JavaParser()),
+            JavaParserFacade.from(JavaParser::new),
             updatesAllMethodNamesChanger,
             EncodingDetector.create());
     this.tmpDir = tmpDir;
@@ -149,7 +149,7 @@ final class JavaParserCodemodRunnerTest {
 
     this.runner =
         new JavaParserCodemodRunner(
-            JavaParserFacade.from(new JavaParser()),
+            JavaParserFacade.from(JavaParser::new),
             new RunsBothCodemod(
                 new UpdatesMethodNamesParserChanger(),
                 new UpdatesClassNamesParserChanger(),

--- a/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/CodemodTestMixin.java
+++ b/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/CodemodTestMixin.java
@@ -127,7 +127,14 @@ public interface CodemodTestMixin {
             List.of(),
             List.of(),
             FileCache.createDefault(),
-            JavaParserFacade.from(factory.create(List.of(dir))),
+            JavaParserFacade.from(
+                () -> {
+                  try {
+                    return factory.create(List.of(dir));
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                }),
             EncodingDetector.create());
     CodeTFResult result = executor.execute(List.of(pathToJavaFile));
     List<CodeTFChangesetEntry> changeset = result.getChangeset();
@@ -191,7 +198,14 @@ public interface CodemodTestMixin {
             List.of(),
             List.of(),
             FileCache.createDefault(),
-            JavaParserFacade.from(factory.create(List.of(dir))),
+            JavaParserFacade.from(
+                () -> {
+                  try {
+                    return factory.create(List.of(dir));
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                }),
             EncodingDetector.create());
     CodeTFResult result2 = executor2.execute(List.of(pathToJavaFile));
     List<CodeTFChangesetEntry> changeset2 = result2.getChangeset();

--- a/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/RawFileCodemodTest.java
+++ b/framework/codemodder-testutils/src/main/java/io/codemodder/testutils/RawFileCodemodTest.java
@@ -78,7 +78,7 @@ public interface RawFileCodemodTest {
             List.of(),
             List.of(),
             FileCache.createDefault(),
-            JavaParserFacade.from(new JavaParser()),
+            JavaParserFacade.from(JavaParser::new),
             EncodingDetector.create());
     CodeTFResult result = executor.execute(List.of(tmpFilePath));
 


### PR DESCRIPTION
This change introduces parallelizing file analysis within a single codemod's execution. This is done primarily with an eye towards systems with slow file I/O.

The changes really boil down to 3 things: 
* created a per-thread copy of a `JavaParser` because they're not intended to be thread-safe
* made per-file analysis threaded
* synchronized post-file change operations (e.g., changing file updates and updating/invalidating caches)