### PR TITLE
Batch Semgrep analysis before execution

### DIFF
--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/DefaultSemgrepRuleFactory.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/DefaultSemgrepRuleFactory.java
@@ -17,14 +17,16 @@ import org.jetbrains.annotations.VisibleForTesting;
 final class DefaultSemgrepRuleFactory implements SemgrepRuleFactory {
 
   @Override
-  public SemgrepRule createYaml(
+  public SemgrepRule createRule(
       final Class<? extends CodeChanger> codemodType,
       final SemgrepScan semgrepScan,
       final String packageName) {
+
     String yamlPath = semgrepScan.pathToYaml();
     String declaredRuleId = semgrepScan.ruleId();
     Path yamlPathToWrite = null;
     boolean foundYaml = false;
+
     if (!declaredRuleId.isEmpty()) {
       String classpathYamlPath =
           "/" + packageName.replace(".", "/") + "/" + declaredRuleId + ".yaml";

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/DefaultSemgrepRuleFactory.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/DefaultSemgrepRuleFactory.java
@@ -1,0 +1,147 @@
+package io.codemodder.providers.sarif.semgrep;
+
+import io.codemodder.CodeChanger;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.VisibleForTesting;
+
+final class DefaultSemgrepRuleFactory implements SemgrepRuleFactory {
+
+  @Override
+  public SemgrepRule createYaml(
+      final Class<? extends CodeChanger> codemodType,
+      final SemgrepScan semgrepScan,
+      final String packageName) {
+    String yamlPath = semgrepScan.pathToYaml();
+    String declaredRuleId = semgrepScan.ruleId();
+    Path yamlPathToWrite = null;
+    boolean foundYaml = false;
+    if (!declaredRuleId.isEmpty()) {
+      String classpathYamlPath =
+          "/" + packageName.replace(".", "/") + "/" + declaredRuleId + ".yaml";
+
+      if (!"".equals(yamlPath)) {
+        classpathYamlPath = yamlPath;
+      }
+      Optional<Path> path = saveClasspathResourceToTemp(codemodType, classpathYamlPath);
+      if (path.isPresent()) {
+        foundYaml = true;
+        yamlPathToWrite = path.get();
+      }
+    }
+    String inlineYaml = semgrepScan.yaml();
+    if (!"".equals(inlineYaml)) {
+      if (foundYaml) {
+        throw new IllegalArgumentException(
+            "Cannot specify both inline yaml and yaml file path: " + codemodType.getName());
+      }
+      foundYaml = true;
+      yamlPathToWrite = saveStringToTemp(inlineYaml);
+    }
+
+    if (!foundYaml) {
+      throw new IllegalArgumentException("no semgrep yaml found for: " + codemodType.getName());
+    }
+
+    try {
+      if (StringUtils.isEmpty(declaredRuleId)) {
+        String rawYaml = Files.readString(yamlPathToWrite);
+        declaredRuleId = detectSingleRuleFromYaml(rawYaml);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Problem inspecting yaml: " + codemodType.getName(), e);
+    }
+
+    try {
+      addMissingPropertiesIfNeeded(yamlPathToWrite);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Problem fixing up yaml: " + codemodType.getName(), e);
+    }
+
+    return new SemgrepRule(semgrepScan, declaredRuleId, yamlPathToWrite);
+  }
+
+  /**
+   * Fix up the yaml and add missing "message", "languages" and "severity" properties if they aren't
+   * there. This makes rule writing easier.
+   */
+  private void addMissingPropertiesIfNeeded(Path yamlPathToWrite) throws IOException {
+    // add missing properties to the yaml
+    boolean changed = false;
+    String yamlAsString = Files.readString(yamlPathToWrite);
+    if (!yamlAsString.contains("message:")) {
+      changed = true;
+      yamlAsString += "\n    message: Semgrep found a match\n";
+    }
+    if (!yamlAsString.contains("severity:")) {
+      changed = true;
+      yamlAsString += "\n    severity: WARNING\n";
+    }
+    if (!yamlAsString.contains("languages:")) {
+      changed = true;
+      yamlAsString += "\n    languages:\n      - java\n";
+    }
+    if (changed) {
+      Files.writeString(yamlPathToWrite, yamlAsString, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+  }
+
+  /** Save the YAML string given to a temporary file. */
+  private Path saveStringToTemp(final String yamlAsString) {
+    try {
+      Path file = Files.createTempFile("semgrep", ".yaml");
+      Files.writeString(file, yamlAsString);
+      return file;
+    } catch (IOException e) {
+      throw new UncheckedIOException("Problem saving yaml string to temp", e);
+    }
+  }
+
+  /**
+   * Turn the yaml resource in the classpath into a file accessible via {@link Path}. Forgive the
+   * exception re-throwing but this is being used from a lambda and this shouldn't fail ever anyway.
+   */
+  private Optional<Path> saveClasspathResourceToTemp(
+      final Class<?> codemodType, final String yamlClasspathResourcePath) {
+    InputStream ruleInputStream = codemodType.getResourceAsStream(yamlClasspathResourcePath);
+    if (ruleInputStream == null) {
+      return Optional.empty();
+    }
+    try {
+      Path semgrepRuleFile = Files.createTempFile("semgrep", ".yaml");
+      Objects.requireNonNull(ruleInputStream);
+      Files.copy(ruleInputStream, semgrepRuleFile, StandardCopyOption.REPLACE_EXISTING);
+      ruleInputStream.close();
+      return Optional.of(semgrepRuleFile);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Problem reading/copying semgrep yaml from classpath", e);
+    } finally {
+      IOUtils.closeQuietly(ruleInputStream);
+    }
+  }
+
+  @VisibleForTesting
+  static String detectSingleRuleFromYaml(final String rawYaml) {
+    String ruleIdStartToken = "- id:";
+    int count = StringUtils.countMatches(rawYaml, ruleIdStartToken);
+    if (count > 1) {
+      throw new IllegalArgumentException(
+          "Multiple rules found in yaml, must specify rule single rule id if implicit");
+    } else if (count == 0) {
+      throw new IllegalArgumentException(
+          "No rules found in yaml, must specify rule single rule id if implicit");
+    }
+    int start = rawYaml.indexOf(ruleIdStartToken);
+    int end = rawYaml.indexOf("\n", start);
+    return rawYaml.substring(start + ruleIdStartToken.length(), end).trim();
+  }
+}

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/DefaultSemgrepRunner.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/DefaultSemgrepRunner.java
@@ -21,7 +21,7 @@ final class DefaultSemgrepRunner implements SemgrepRunner {
 
   @Override
   public SarifSchema210 run(
-      final Path ruleYaml,
+      final List<Path> ruleYamls,
       final Path repository,
       final List<String> includePatterns,
       final List<String> excludePatterns)
@@ -48,8 +48,10 @@ final class DefaultSemgrepRunner implements SemgrepRunner {
       args.add(excludedFilePath);
     }
 
-    args.add("--config");
-    args.add(ruleYaml.toString());
+    for (Path ruleYaml : ruleYamls) {
+      args.add("--config");
+      args.add(ruleYaml.toString());
+    }
 
     args.add(repositoryPath.toString());
 

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepModule.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepModule.java
@@ -134,7 +134,7 @@ public final class SemgrepModule extends AbstractModule {
 
               SemgrepScan semgrepScan = param.getAnnotation(SemgrepScan.class);
               SemgrepRule rule =
-                  semgrepRuleFactory.createYaml(codemodType, semgrepScan, packageName);
+                  semgrepRuleFactory.createRule(codemodType, semgrepScan, packageName);
               rules.add(rule);
             });
 

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepModule.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepModule.java
@@ -1,5 +1,6 @@
 package io.codemodder.providers.sarif.semgrep;
 
+import com.contrastsecurity.sarif.Result;
 import com.contrastsecurity.sarif.SarifSchema210;
 import com.google.inject.AbstractModule;
 import io.codemodder.CodeChanger;
@@ -7,19 +8,14 @@ import io.codemodder.LazyLoadingRuleSarif;
 import io.codemodder.RuleSarif;
 import io.github.classgraph.*;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.*;
 import javax.inject.Inject;
 import javax.inject.Provider;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +29,7 @@ public final class SemgrepModule extends AbstractModule {
   private final List<RuleSarif> sarifs;
   private final List<String> includePatterns;
   private final List<String> excludePatterns;
+  private final SemgrepRuleFactory semgrepRuleFactory;
 
   @VisibleForTesting
   SemgrepModule(
@@ -40,7 +37,13 @@ public final class SemgrepModule extends AbstractModule {
       final List<String> includePatterns,
       final List<String> excludePatterns,
       final List<Class<? extends CodeChanger>> codemodTypes) {
-    this(codeDirectory, includePatterns, excludePatterns, codemodTypes, List.of());
+    this(
+        codeDirectory,
+        includePatterns,
+        excludePatterns,
+        codemodTypes,
+        List.of(),
+        new DefaultSemgrepRuleFactory());
   }
 
   public SemgrepModule(
@@ -48,13 +51,15 @@ public final class SemgrepModule extends AbstractModule {
       final List<String> includePatterns,
       final List<String> excludePatterns,
       final List<Class<? extends CodeChanger>> codemodTypes,
-      final List<RuleSarif> sarifs) {
+      final List<RuleSarif> sarifs,
+      final SemgrepRuleFactory semgrepRuleFactory) {
     this.codemodTypes = Objects.requireNonNull(codemodTypes);
     this.codeDirectory = Objects.requireNonNull(codeDirectory);
     this.includePatterns = Objects.requireNonNull(includePatterns);
     this.excludePatterns = Objects.requireNonNull(excludePatterns);
     this.semgrepRunner = SemgrepRunner.createDefault();
     this.sarifs = Objects.requireNonNull(sarifs);
+    this.semgrepRuleFactory = Objects.requireNonNull(semgrepRuleFactory);
   }
 
   @Override
@@ -62,6 +67,8 @@ public final class SemgrepModule extends AbstractModule {
 
     // find all the @ProvidedSemgrepScan annotations and bind them as is
     Set<String> packagesScanned = new HashSet<>();
+
+    List<SemgrepRule> rules = new ArrayList<>();
 
     for (Class<? extends CodeChanger> codemodType : codemodTypes) {
 
@@ -128,18 +135,9 @@ public final class SemgrepModule extends AbstractModule {
               }
 
               SemgrepScan semgrepScan = param.getAnnotation(SemgrepScan.class);
-              SemgrepSarifProvider semgrepSarifProvider =
-                  new SemgrepSarifProvider(
-                      codeDirectory,
-                      semgrepScan,
-                      codemodType,
-                      semgrepRunner,
-                      packageName,
-                      includePatterns,
-                      excludePatterns);
-              LazyLoadingRuleSarif lazyLoadingRuleSarif =
-                  new LazyLoadingRuleSarif(semgrepSarifProvider);
-              bind(RuleSarif.class).annotatedWith(semgrepScan).toInstance(lazyLoadingRuleSarif);
+              SemgrepRule rule =
+                  semgrepRuleFactory.createYaml(codemodType, semgrepScan, packageName);
+              rules.add(rule);
             });
 
         LOG.trace("Finished scanning codemod package: {}", packageName);
@@ -147,181 +145,80 @@ public final class SemgrepModule extends AbstractModule {
       }
     }
 
-    // fix up the yaml and add missing "message", "languages" and "severity" properties if they
-    // aren't there
+    /*
+     * To avoid running semgrep and eating heavy, redundant file I/O for every codemod, we'll run it once with all rules, calculate which rules didn't "hit", and then storing an empty result for them. This will allow us to only run Semgrep on the rules for which we have evidence will hit. Given that we don't expect most projects to hit most codemods, this is a big time-savings.
+     */
+    final List<String> rawRulesFoundInBatchRun;
+    try {
+      SarifSchema210 allRulesSarif =
+          semgrepRunner.run(
+              rules.stream().map(SemgrepRule::yaml).toList(),
+              codeDirectory,
+              includePatterns,
+              excludePatterns);
+      rawRulesFoundInBatchRun =
+          allRulesSarif.getRuns().get(0).getResults().stream().map(Result::getRuleId).toList();
+    } catch (IOException e) {
+      throw new UncheckedIOException("problem running batched execution", e);
+    }
 
+    for (SemgrepRule rule : rules) {
+      SemgrepScan semgrepScan = rule.semgrepScan();
+      if (rawRulesFoundInBatchRun.stream().anyMatch(r -> r.endsWith("." + rule.ruleId()))) {
+        SemgrepSarifProvider semgrepSarifProvider =
+            new SemgrepSarifProvider(
+                codeDirectory,
+                includePatterns,
+                excludePatterns,
+                semgrepRunner,
+                rule.yaml(),
+                rule.ruleId());
+        LazyLoadingRuleSarif lazyLoadingRuleSarif = new LazyLoadingRuleSarif(semgrepSarifProvider);
+        bind(RuleSarif.class).annotatedWith(semgrepScan).toInstance(lazyLoadingRuleSarif);
+      } else {
+        bind(RuleSarif.class).annotatedWith(semgrepScan).toInstance(RuleSarif.EMPTY);
+      }
+    }
   }
 
   private record SemgrepSarifProvider(
       Path codeDirectory,
-      SemgrepScan semgrepScan,
-      Class<? extends CodeChanger> codemodType,
-      SemgrepRunner semgrepRunner,
-      String packageName,
       List<String> includePatterns,
-      List<String> excludePatterns)
+      List<String> excludePatterns,
+      SemgrepRunner semgrepRunner,
+      Path yaml,
+      String ruleId)
       implements Provider<RuleSarif> {
 
-    private SemgrepSarifProvider(
-        final Path codeDirectory,
-        final SemgrepScan semgrepScan,
-        final Class<? extends CodeChanger> codemodType,
-        final SemgrepRunner semgrepRunner,
-        final String packageName,
-        final List<String> includePatterns,
-        final List<String> excludePatterns) {
-
-      this.codemodType = Objects.requireNonNull(codemodType);
-      this.semgrepScan = Objects.requireNonNull(semgrepScan);
-      this.semgrepRunner = Objects.requireNonNull(semgrepRunner);
-      this.packageName = Objects.requireNonNull(packageName);
-      this.codeDirectory = Objects.requireNonNull(codeDirectory);
-      this.includePatterns = Objects.requireNonNull(includePatterns);
-      this.excludePatterns = Objects.requireNonNull(excludePatterns);
+    SemgrepSarifProvider {
+      Objects.requireNonNull(semgrepRunner);
+      Objects.requireNonNull(codeDirectory);
+      Objects.requireNonNull(includePatterns);
+      Objects.requireNonNull(excludePatterns);
     }
 
     @Override
     public RuleSarif get() {
-      String yamlPath = semgrepScan.pathToYaml();
-      String declaredRuleId = semgrepScan.ruleId();
-      Path yamlPathToWrite = null;
-      boolean foundYaml = false;
-      if (!declaredRuleId.isEmpty()) {
-        String classpathYamlPath =
-            "/" + packageName.replace(".", "/") + "/" + declaredRuleId + ".yaml";
-
-        if (!"".equals(yamlPath)) {
-          classpathYamlPath = yamlPath;
-        }
-        Optional<Path> path = saveClasspathResourceToTemp(codemodType, classpathYamlPath);
-        if (path.isPresent()) {
-          foundYaml = true;
-          yamlPathToWrite = path.get();
-        }
-      }
-      String inlineYaml = semgrepScan.yaml();
-      if (!"".equals(inlineYaml)) {
-        if (foundYaml) {
-          throw new IllegalArgumentException(
-              "Cannot specify both inline yaml and yaml file path: " + codemodType.getName());
-        }
-        foundYaml = true;
-        yamlPathToWrite = saveStringToTemp(inlineYaml);
-      }
-
-      if (!foundYaml) {
-        throw new IllegalArgumentException("no semgrep yaml found for: " + codemodType.getName());
-      }
-
-      try {
-        if (StringUtils.isEmpty(declaredRuleId)) {
-          String rawYaml = Files.readString(yamlPathToWrite);
-          declaredRuleId = detectSingleRuleFromYaml(rawYaml);
-        }
-      } catch (IOException e) {
-        throw new UncheckedIOException("Problem inspecting yaml: " + codemodType.getName(), e);
-      }
-
-      try {
-        addMissingPropertiesIfNeeded(yamlPathToWrite);
-      } catch (IOException e) {
-        throw new UncheckedIOException("Problem fixing up yaml: " + codemodType.getName(), e);
-      }
 
       // actually run the SARIF only once
       SarifSchema210 sarif;
       try {
-        sarif = semgrepRunner.run(yamlPathToWrite, codeDirectory, includePatterns, excludePatterns);
+        sarif = semgrepRunner.run(List.of(yaml), codeDirectory, includePatterns, excludePatterns);
       } catch (IOException e) {
         throw new IllegalArgumentException("Semgrep execution failed", e);
       }
-      SemgrepRuleSarif semgrepSarif = new SemgrepRuleSarif(declaredRuleId, sarif, codeDirectory);
+      SingleSemgrepRuleSarif semgrepSarif =
+          new SingleSemgrepRuleSarif(ruleId, sarif, codeDirectory);
 
       // clean up the temporary files
       try {
-        Files.delete(yamlPathToWrite);
+        Files.delete(yaml);
       } catch (IOException e) {
-        LOG.warn("Failed to delete temporary file: {}", yamlPathToWrite, e);
+        LOG.warn("Failed to delete temporary file: {}", yaml, e);
       }
 
       return semgrepSarif;
     }
-
-    /**
-     * Fix up the yaml and add missing "message", "languages" and "severity" properties if they
-     * aren't there. This makes rule writing easier.
-     */
-    private static void addMissingPropertiesIfNeeded(Path yamlPathToWrite) throws IOException {
-      // add missing properties to the yaml
-      boolean changed = false;
-      String yamlAsString = Files.readString(yamlPathToWrite);
-      if (!yamlAsString.contains("message:")) {
-        changed = true;
-        yamlAsString += "\n    message: Semgrep found a match\n";
-      }
-      if (!yamlAsString.contains("severity:")) {
-        changed = true;
-        yamlAsString += "\n    severity: WARNING\n";
-      }
-      if (!yamlAsString.contains("languages:")) {
-        changed = true;
-        yamlAsString += "\n    languages:\n      - java\n";
-      }
-      if (changed) {
-        Files.writeString(yamlPathToWrite, yamlAsString, StandardOpenOption.TRUNCATE_EXISTING);
-      }
-    }
-
-    /** Save the YAML string given to a temporary file. */
-    private Path saveStringToTemp(final String yamlAsString) {
-      try {
-        Path file = Files.createTempFile("semgrep", ".yaml");
-        Files.writeString(file, yamlAsString);
-        return file;
-      } catch (IOException e) {
-        throw new UncheckedIOException("Problem saving yaml string to temp", e);
-      }
-    }
-
-    /**
-     * Turn the yaml resource in the classpath into a file accessible via {@link Path}. Forgive the
-     * exception re-throwing but this is being used from a lambda and this shouldn't fail ever
-     * anyway.
-     */
-    private Optional<Path> saveClasspathResourceToTemp(
-        final Class<?> codemodType, final String yamlClasspathResourcePath) {
-      InputStream ruleInputStream = codemodType.getResourceAsStream(yamlClasspathResourcePath);
-      if (ruleInputStream == null) {
-        return Optional.empty();
-      }
-      try {
-        Path semgrepRuleFile = Files.createTempFile("semgrep", ".yaml");
-        Objects.requireNonNull(ruleInputStream);
-        Files.copy(ruleInputStream, semgrepRuleFile, StandardCopyOption.REPLACE_EXISTING);
-        ruleInputStream.close();
-        return Optional.of(semgrepRuleFile);
-      } catch (IOException e) {
-        throw new UncheckedIOException("Problem reading/copying semgrep yaml from classpath", e);
-      } finally {
-        IOUtils.closeQuietly(ruleInputStream);
-      }
-    }
-  }
-
-  @VisibleForTesting
-  static String detectSingleRuleFromYaml(final String rawYaml) {
-    String ruleIdStartToken = "- id:";
-    int count = StringUtils.countMatches(rawYaml, ruleIdStartToken);
-    if (count > 1) {
-      throw new IllegalArgumentException(
-          "Multiple rules found in yaml, must specify rule single rule id if implicit");
-    } else if (count == 0) {
-      throw new IllegalArgumentException(
-          "No rules found in yaml, must specify rule single rule id if implicit");
-    }
-    int start = rawYaml.indexOf(ruleIdStartToken);
-    int end = rawYaml.indexOf("\n", start);
-    return rawYaml.substring(start + ruleIdStartToken.length(), end).trim();
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(SemgrepModule.class);

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepModule.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepModule.java
@@ -16,7 +16,6 @@ import java.nio.file.Path;
 import java.util.*;
 import javax.inject.Inject;
 import javax.inject.Provider;
-import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,8 +30,7 @@ public final class SemgrepModule extends AbstractModule {
   private final List<String> excludePatterns;
   private final SemgrepRuleFactory semgrepRuleFactory;
 
-  @VisibleForTesting
-  SemgrepModule(
+  public SemgrepModule(
       final Path codeDirectory,
       final List<String> includePatterns,
       final List<String> excludePatterns,

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepProvider.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepProvider.java
@@ -20,7 +20,13 @@ public final class SemgrepProvider implements CodemodProvider {
       final List<Class<? extends CodeChanger>> codemodTypes,
       final List<RuleSarif> sarifs) {
     return Set.of(
-        new SemgrepModule(codeDirectory, includePaths, excludePaths, codemodTypes, sarifs));
+        new SemgrepModule(
+            codeDirectory,
+            includePaths,
+            excludePaths,
+            codemodTypes,
+            sarifs,
+            new DefaultSemgrepRuleFactory()));
   }
 
   @Override

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRule.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRule.java
@@ -3,6 +3,9 @@ package io.codemodder.providers.sarif.semgrep;
 import java.nio.file.Path;
 import java.util.Objects;
 
+/**
+ * Represents a Semgrep rule with all the metadata it needs to be run and associated with a scan.
+ */
 record SemgrepRule(SemgrepScan semgrepScan, String ruleId, Path yaml) {
 
   SemgrepRule {

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRule.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRule.java
@@ -1,0 +1,13 @@
+package io.codemodder.providers.sarif.semgrep;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+record SemgrepRule(SemgrepScan semgrepScan, String ruleId, Path yaml) {
+
+  SemgrepRule {
+    Objects.requireNonNull(semgrepScan);
+    Objects.requireNonNull(ruleId);
+    Objects.requireNonNull(yaml);
+  }
+}

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRuleFactory.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRuleFactory.java
@@ -1,0 +1,16 @@
+package io.codemodder.providers.sarif.semgrep;
+
+import io.codemodder.CodeChanger;
+
+/** A type that creates codemodder-ready Semgrep YAML rules ready for execution. */
+interface SemgrepRuleFactory {
+
+  /**
+   * Given the user's configuration data, return a definition of a rule that can be used by
+   * codemodder.
+   */
+  SemgrepRule createYaml(
+      Class<? extends CodeChanger> codemodType,
+      final SemgrepScan scanInfo,
+      final String packageName);
+}

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRuleFactory.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRuleFactory.java
@@ -9,8 +9,6 @@ interface SemgrepRuleFactory {
    * Given the user's configuration data, return a definition of a rule that can be used by
    * codemodder.
    */
-  SemgrepRule createYaml(
-      Class<? extends CodeChanger> codemodType,
-      final SemgrepScan scanInfo,
-      final String packageName);
+  SemgrepRule createRule(
+      Class<? extends CodeChanger> codemodType, SemgrepScan scanInfo, String packageName);
 }

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRuleSarifFactory.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRuleSarifFactory.java
@@ -6,14 +6,14 @@ import io.codemodder.RuleSarifFactory;
 import java.nio.file.Path;
 import java.util.Optional;
 
-/** A factory for building {@link SemgrepRuleSarif}s. */
+/** A factory for building {@link SingleSemgrepRuleSarif}s. */
 public class SemgrepRuleSarifFactory implements RuleSarifFactory {
 
   @Override
   public Optional<RuleSarif> build(
       String toolName, String rule, SarifSchema210 sarif, Path repositoryRoot) {
-    if (SemgrepRuleSarif.toolName.equals(toolName)) {
-      return Optional.of(new SemgrepRuleSarif(rule, sarif, repositoryRoot));
+    if (SingleSemgrepRuleSarif.toolName.equals(toolName)) {
+      return Optional.of(new SingleSemgrepRuleSarif(rule, sarif, repositoryRoot));
     }
     return Optional.empty();
   }

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRunner.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SemgrepRunner.java
@@ -11,12 +11,12 @@ public interface SemgrepRunner {
   /**
    * Execute semgrep.
    *
-   * @param yaml the file where the rule(s) are stored
+   * @param yamls the file(s) where the rule(s) are stored
    * @param codeDir the directory containing the code to be run on
    * @return the resulting SARIF
    */
   SarifSchema210 run(
-      Path yaml, Path codeDir, List<String> includePatterns, List<String> excludePatterns)
+      List<Path> yamls, Path codeDir, List<String> includePatterns, List<String> excludePatterns)
       throws IOException;
 
   static SemgrepRunner createDefault() {

--- a/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SingleSemgrepRuleSarif.java
+++ b/plugins/codemodder-plugin-semgrep/src/main/java/io/codemodder/providers/sarif/semgrep/SingleSemgrepRuleSarif.java
@@ -20,14 +20,15 @@ import java.util.Objects;
  * places the whole path to the rule in the field. This means our filtering logic is a little weird
  * and unexpected, but it works.
  */
-final class SemgrepRuleSarif implements RuleSarif {
+final class SingleSemgrepRuleSarif implements RuleSarif {
 
   private final SarifSchema210 sarif;
   private final String ruleId;
   private final Map<Path, List<Result>> resultsCache;
   private final Path repositoryRoot;
 
-  SemgrepRuleSarif(final String ruleId, final SarifSchema210 sarif, final Path repositoryRoot) {
+  SingleSemgrepRuleSarif(
+      final String ruleId, final SarifSchema210 sarif, final Path repositoryRoot) {
     this.sarif = Objects.requireNonNull(sarif);
     this.ruleId = Objects.requireNonNull(ruleId);
     this.repositoryRoot = Objects.requireNonNull(repositoryRoot);

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepJavaParserChangerTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepJavaParserChangerTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.contrastsecurity.sarif.Result;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.google.inject.CreationException;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import io.codemodder.*;
@@ -46,12 +47,8 @@ final class SemgrepJavaParserChangerTest {
     SemgrepModule module =
         new SemgrepModule(
             tmpDir, List.of("**"), List.of(), List.of(InvalidUsesBothYamlStrategies.class));
-    Injector injector = Guice.createInjector(module);
-    InvalidUsesBothYamlStrategies instance =
-        injector.getInstance(InvalidUsesBothYamlStrategies.class);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> instance.sarif.getRegionsFromResultsByRule(Path.of("anything")));
+
+    assertThrows(CreationException.class, () -> Guice.createInjector(module));
   }
 
   private Path writeJavaFile(final Path tmpDir, final String javaCode) throws IOException {

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepModuleTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepModuleTest.java
@@ -196,20 +196,20 @@ final class SemgrepModuleTest {
   }
 
   @Test
-  void it_detects_rule_ids(final @TempDir Path tmpDir) throws IOException {
-    SemgrepModule module = createModule(tmpDir, List.of(UsesImplicitYamlPath.class));
-
-    String id = module.detectSingleRuleFromYaml("rules:\n  - id: foo\n    pattern: bar\n");
+  void it_detects_rule_ids() {
+    String id =
+        DefaultSemgrepRuleFactory.detectSingleRuleFromYaml(
+            "rules:\n  - id: foo\n    pattern: bar\n");
     assertThat(id, is("foo"));
 
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            module.detectSingleRuleFromYaml(
+            DefaultSemgrepRuleFactory.detectSingleRuleFromYaml(
                 "rules:\n  - id: foo\n  - id: bar\n    pattern: baz\n"));
     assertThrows(
         IllegalArgumentException.class,
-        () -> module.detectSingleRuleFromYaml("rules:\n  - pattern: baz\n"));
+        () -> DefaultSemgrepRuleFactory.detectSingleRuleFromYaml("rules:\n  - pattern: baz\n"));
   }
 
   private SemgrepModule createModule(
@@ -242,7 +242,8 @@ final class SemgrepModuleTest {
             List.of("**"),
             List.of(),
             List.of(UsesOfflineSemgrepCodemod.class),
-            map.entrySet().iterator().next().getValue());
+            map.entrySet().iterator().next().getValue(),
+            new DefaultSemgrepRuleFactory());
     Injector injector = Guice.createInjector(module);
     UsesOfflineSemgrepCodemod instance = injector.getInstance(UsesOfflineSemgrepCodemod.class);
 

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepRunnerTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/SemgrepRunnerTest.java
@@ -33,7 +33,7 @@ final class SemgrepRunnerTest {
 
     // run the scan
     SarifSchema210 sarif =
-        new DefaultSemgrepRunner().run(ruleFile, repositoryDir, List.of("**"), List.of());
+        new DefaultSemgrepRunner().run(List.of(ruleFile), repositoryDir, List.of("**"), List.of());
 
     // assert the scan went as we think it should
     List<Run> runs = sarif.getRuns();

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bindstoincorrect/BindsToIncorrectObjectTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bindstoincorrect/BindsToIncorrectObjectTest.java
@@ -15,8 +15,7 @@ final class BindsToIncorrectObjectTest {
   @Test
   void it_fails_when_injecting_nonsarif_type(@TempDir Path tmpDir) {
     SemgrepModule module =
-        new SemgrepModule(
-            tmpDir, List.of("**"), List.of(), List.of(BindsToIncorrectObject.class), List.of());
+        new SemgrepModule(tmpDir, List.of("**"), List.of(), List.of(BindsToIncorrectObject.class));
     assertThrows(
         CreationException.class,
         () -> {

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bindstoincorrect/BindsToIncorrectObjectTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bindstoincorrect/BindsToIncorrectObjectTest.java
@@ -16,10 +16,6 @@ final class BindsToIncorrectObjectTest {
   void it_fails_when_injecting_nonsarif_type(@TempDir Path tmpDir) {
     SemgrepModule module =
         new SemgrepModule(tmpDir, List.of("**"), List.of(), List.of(BindsToIncorrectObject.class));
-    assertThrows(
-        CreationException.class,
-        () -> {
-          Guice.createInjector(module);
-        });
+    assertThrows(CreationException.class, () -> Guice.createInjector(module));
   }
 }

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bothyamlstrategies/InvalidUsesBothYamlStrategiesTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bothyamlstrategies/InvalidUsesBothYamlStrategiesTest.java
@@ -16,11 +16,7 @@ final class InvalidUsesBothYamlStrategiesTest {
   void it_fails_when_using_both_strategies(@TempDir Path tmpDir) {
     SemgrepModule module =
         new SemgrepModule(
-            tmpDir,
-            List.of("**"),
-            List.of(),
-            List.of(InvalidUsesBothYamlStrategies.class),
-            List.of());
+            tmpDir, List.of("**"), List.of(), List.of(InvalidUsesBothYamlStrategies.class));
     Injector injector = Guice.createInjector(module);
     InvalidUsesBothYamlStrategies instance =
         injector.getInstance(InvalidUsesBothYamlStrategies.class);

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bothyamlstrategies/InvalidUsesBothYamlStrategiesTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/bothyamlstrategies/InvalidUsesBothYamlStrategiesTest.java
@@ -2,8 +2,8 @@ package io.codemodder.providers.sarif.semgrep.invalid.bothyamlstrategies;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.inject.CreationException;
 import com.google.inject.Guice;
-import com.google.inject.Injector;
 import io.codemodder.providers.sarif.semgrep.SemgrepModule;
 import java.nio.file.Path;
 import java.util.List;
@@ -17,13 +17,6 @@ final class InvalidUsesBothYamlStrategiesTest {
     SemgrepModule module =
         new SemgrepModule(
             tmpDir, List.of("**"), List.of(), List.of(InvalidUsesBothYamlStrategies.class));
-    Injector injector = Guice.createInjector(module);
-    InvalidUsesBothYamlStrategies instance =
-        injector.getInstance(InvalidUsesBothYamlStrategies.class);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          instance.sarif.getRegionsFromResultsByRule(Path.of("anything"));
-        });
+    assertThrows(CreationException.class, () -> Guice.createInjector(module));
   }
 }

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/implicitbutmultiplerules/UsesImplicitButHasMultipleRulesTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/implicitbutmultiplerules/UsesImplicitButHasMultipleRulesTest.java
@@ -2,8 +2,8 @@ package io.codemodder.providers.sarif.semgrep.invalid.implicitbutmultiplerules;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.inject.CreationException;
 import com.google.inject.Guice;
-import com.google.inject.Injector;
 import io.codemodder.providers.sarif.semgrep.SemgrepModule;
 import java.nio.file.Path;
 import java.util.List;
@@ -17,13 +17,6 @@ final class UsesImplicitButHasMultipleRulesTest {
     SemgrepModule module =
         new SemgrepModule(
             tmpDir, List.of("**"), List.of(), List.of(UsesImplicitButHasMultipleRules.class));
-    Injector injector = Guice.createInjector(module);
-    UsesImplicitButHasMultipleRules instance =
-        injector.getInstance(UsesImplicitButHasMultipleRules.class);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          instance.sarif.getRegionsFromResultsByRule(Path.of("anything"));
-        });
+    assertThrows(CreationException.class, () -> Guice.createInjector(module));
   }
 }

--- a/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/implicitbutmultiplerules/UsesImplicitButHasMultipleRulesTest.java
+++ b/plugins/codemodder-plugin-semgrep/src/test/java/io/codemodder/providers/sarif/semgrep/invalid/implicitbutmultiplerules/UsesImplicitButHasMultipleRulesTest.java
@@ -16,11 +16,7 @@ final class UsesImplicitButHasMultipleRulesTest {
   void it_fails_when_implicit_rule_but_multiple_specified(@TempDir Path tmpDir) {
     SemgrepModule module =
         new SemgrepModule(
-            tmpDir,
-            List.of("**"),
-            List.of(),
-            List.of(UsesImplicitButHasMultipleRules.class),
-            List.of());
+            tmpDir, List.of("**"), List.of(), List.of(UsesImplicitButHasMultipleRules.class));
     Injector injector = Guice.createInjector(module);
     UsesImplicitButHasMultipleRules instance =
         injector.getInstance(UsesImplicitButHasMultipleRules.class);


### PR DESCRIPTION
Right now we run Semgrep for each individual Semgrep-assisted codemod. Assuming there are 100 files and 10 Semgrep codemods, this means there are 1,000 file reads executed in a given “scan”. 

However, let’s assume that the average case is there are actually 3 “hits” for Semgrep codemods. It’s possible to design a system more optimized to prevent extra file reads. 

This “batch-and-re-run” strategy change batches all the Semgrep rules together and runs them once before any codemod execution. So, in our example, this means we'd run Semgrep _once_, but with all 3 rules. This would mean 100 files would be read to find the “3 hits”. The framework would then operate as normal, except for the 7 which didn’t hit, it would ****not**** re-run Semgrep again.

This would mean a reduction in file reads from 1,000 to 600. I anticipate this would bring the cost of the average case down a lot.