### PR TITLE
Build and push test project image

### DIFF
--- a/.github/workflows/build-and-push-test-project-image.yml
+++ b/.github/workflows/build-and-push-test-project-image.yml
@@ -1,0 +1,43 @@
+name: Build and push test project image
+
+on:
+  workflow_dispatch:
+    inputs:
+      codemodder-base-image:
+        description: Codemodder base image which will be used to run the codemods
+        type: string
+        required: true
+      codemod-id:
+        description: ID of the codemod for which the test project image is being generated
+        type: string
+        required: true
+
+jobs:
+  build-and-push:
+    name: Build and Push test project image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          file: core-codemods/src/test/java/io/codemodder/codemods/integration/projectimage/Dockerfile
+          push: true
+          build-args: |
+            #          replace personal account
+                        CODEMODDER_BASE_IMAGE=arturoiwa/${{ github.event.inputs.codemodder-base-image }}
+                        CODEMOD_ID=${{ github.event.inputs.codemod-id }}
+          tags: arturoiwa/${{ github.event.inputs.codemod-id }}:latest
+


### PR DESCRIPTION
Overview: 
A test project base image is used in the construction of the image used by test containers created on the fly during each integration test. 
these project images need to be pulled from an image registry to make each integration test able to run

What change:
- action to build and push a test project image is added