### PR TITLE
:recycle: use version catalogs rather than inlining versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,3 +50,11 @@ picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "pico
 progressbar = "me.tongfei:progressbar:0.9.3"
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 tuples = "org.javatuples:javatuples:1.2"
+kotlinStdlibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version = "1.7.10" }
+jaxen = { module = "jaxen:jaxen", version = "1.2.0" }
+xerces-impl = { module = "xerces:xercesImpl", version = "2.12.2" }
+xmlunit-core = { module = "org.xmlunit:xmlunit-core", version = "2.9.0" }
+xmlunit-assertj3 = { module = "org.xmlunit:xmlunit-assertj3", version = "2.9.0" }
+java-semver = { module = "com.github.zafarkhaja:java-semver", version = "0.9.0" }
+diff-match-patch = { module = "fun.mike:diff-match-patch", version = "0.0.2" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,6 @@ kotlinStdlibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version
 jaxen = { module = "jaxen:jaxen", version = "1.2.0" }
 xerces-impl = { module = "xerces:xercesImpl", version = "2.12.2" }
 xmlunit-core = { module = "org.xmlunit:xmlunit-core", version = "2.9.0" }
-xmlunit-assertj3 = { module = "org.xmlunit:xmlunit-assertj3", version = "2.9.0" }
 java-semver = { module = "com.github.zafarkhaja:java-semver", version = "0.9.0" }
 diff-match-patch = { module = "fun.mike:diff-match-patch", version = "0.0.2" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }

--- a/gradle/testlibs.versions.toml
+++ b/gradle/testlibs.versions.toml
@@ -6,6 +6,7 @@ junit-jupiter = "5.8.2"
 assertj = "org.assertj:assertj-core:3.24.0"
 hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }
 hamcrest-library = { module = "org.hamcrest:hamcrest-library", version.ref = "hamcrest" }
+hamcrest-all = { module = "org.hamcrest:hamcrest-all", version = "1.3" }
 jgit = "org.eclipse.jgit:org.eclipse.jgit:3.5.0.201409260305-r"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }

--- a/gradle/testlibs.versions.toml
+++ b/gradle/testlibs.versions.toml
@@ -12,6 +12,7 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.re
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
 mockito = "org.mockito:mockito-core:4.3.1"
+xmlunit-assertj3 = { module = "org.xmlunit:xmlunit-assertj3", version = "2.9.0" }
 
 [bundles]
 hamcrest = ["hamcrest-core", "hamcrest-library"]

--- a/plugins/codemodder-plugin-maven/build.gradle.kts
+++ b/plugins/codemodder-plugin-maven/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     implementation(libs.jaxen)
     implementation(libs.xerces.impl)
     implementation(libs.xmlunit.core)
-    implementation(libs.xmlunit.assertj3)
+    implementation(testlibs.xmlunit.assertj3)
     implementation(libs.java.semver)
     implementation(libs.juniversalchardet)
     implementation(libs.java.security.toolkit)

--- a/plugins/codemodder-plugin-maven/build.gradle.kts
+++ b/plugins/codemodder-plugin-maven/build.gradle.kts
@@ -6,43 +6,29 @@ plugins {
 description = "Plugin for providing Maven dependency management functions to codemods."
 
 dependencies {
-    val commonsLangVersion = "3.12.0"
-    val dom4jVersion = "2.1.3"
-    val jaxenVersion = "1.2.0"
-    val xercesImplVersion = "2.12.2"
-    val xmlUnitVersion = "2.9.0"
-    val kotlinVersion = "1.7.10"
-    val javaSemverVersion = "0.9.0"
-    val slf4jSimpleVersion = "2.0.0"
-    val hamcrestVersion = "1.3"
-    val kotlinTestVersion = "1.7.10"
-    val slf4jApiVersion = "2.0.0"
-    val juniversalchardetVersion = "2.4.0"
-    val diffMatchPatchVersion = "0.0.2"
 
     compileOnly(libs.jetbrains.annotations)
     implementation(project(":framework:codemodder-base"))
 
     testImplementation(testlibs.bundles.junit.jupiter)
     testImplementation(testlibs.bundles.hamcrest)
+    testImplementation(testlibs.hamcrest.all)
     testImplementation(testlibs.assertj)
     testImplementation(testlibs.jgit)
     testImplementation(testlibs.mockito)
     testRuntimeOnly(testlibs.junit.jupiter.engine)
 
-    implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
-    implementation("org.dom4j:dom4j:$dom4jVersion")
-    implementation("jaxen:jaxen:$jaxenVersion")
-    implementation("xerces:xercesImpl:$xercesImplVersion")
-    implementation("org.xmlunit:xmlunit-core:$xmlUnitVersion")
-    implementation("org.xmlunit:xmlunit-assertj3:$xmlUnitVersion")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
-    implementation("com.github.zafarkhaja:java-semver:$javaSemverVersion")
-    implementation("com.github.albfernandez:juniversalchardet:$juniversalchardetVersion")
+    implementation(libs.commons.lang3)
+    implementation(libs.kotlinStdlibJdk8)
+    implementation(libs.dom4j)
+    implementation(libs.jaxen)
+    implementation(libs.xerces.impl)
+    implementation(libs.xmlunit.core)
+    implementation(libs.xmlunit.assertj3)
+    implementation(libs.java.semver)
+    implementation(libs.juniversalchardet)
     implementation(libs.java.security.toolkit)
-    testImplementation("fun.mike:diff-match-patch:$diffMatchPatchVersion")
-    testImplementation("org.slf4j:slf4j-simple:$slf4jSimpleVersion")
-    testImplementation("org.hamcrest:hamcrest-all:$hamcrestVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinTestVersion")
-    compileOnly("org.slf4j:slf4j-api:$slf4jApiVersion")
+    implementation(libs.diff.match.patch)
+    implementation(libs.slf4j.simple)
+    implementation(libs.slf4j.api)
 }

--- a/plugins/codemodder-plugin-maven/src/test/java/io/codemodder/plugins/maven/operator/PropertyResolutionTest.java
+++ b/plugins/codemodder-plugin-maven/src/test/java/io/codemodder/plugins/maven/operator/PropertyResolutionTest.java
@@ -7,13 +7,12 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import junit.framework.TestCase;
 import org.dom4j.DocumentException;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class PropertyResolutionTest extends TestCase {
+final class PropertyResolutionTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PropertyResolutionTest.class);
 


### PR DESCRIPTION
- define dependency versions and coordinates in a version catalog
- Remove unneeded dependencies/reduce their scope