### PR TITLE
Update release name and documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ inputs.version }}
-          release_name: Release ${{ inputs.version }}
+          tag_name: v${{ inputs.version }}
+          release_name: v${{ inputs.version }}
           draft: false
           prerelease: false
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ python -m site
 ```
 
 ### Run the Core Codemods
+You can download and run the latest release from this repository in order to run the core codemods as a CLI:
+
+```bash
+$ unzip codemodder-java-codemods-<VERSION>.zip
+$ sh core-codemods-<VERSION>/bin/core-codemods
+```
+
+In order to run them during active development from Gradle, you can use the `run` task:
+
 ```shell
 ./gradlew :core-codemods:run --args='--output /path/to/my.codetf --dry-run /path/to/project/'
 ```


### PR DESCRIPTION
* Changes release and tag names to be the simple semantic version.
* Adds documentation to the `README` on how to use it as a CLI.
