### PR TITLE
Make output file optional and create output file parent dirs if necessary

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -281,16 +281,19 @@ final class CLI implements Callable<Integer> {
 
     Path outputPath = null;
     if (output != null) {
-      outputPath = output.toPath();
-
-      // check if the output file parent directory doesn't exist
-      if (!Files.exists(outputPath.getParent())) {
-        // create it
-        Files.createDirectories(outputPath.getParent());
+      outputPath = output.getAbsoluteFile().toPath();
+      if(!Files.exists(outputPath)) {
+        Files.createFile(outputPath);
       }
 
-      if (!Files.isWritable(outputPath) && !Files.isWritable(outputPath.getParent())) {
-        log.error("The output file (or its parent directory) is not writable");
+      // check if the output file parent directory doesn't exist or isn't writable
+      if (!Files.exists(outputPath.getParent()) || !Files.isWritable(outputPath.getParent())) {
+        log.error("The output file parent directory doesn't exist");
+        return ERROR_CANT_WRITE_OUTPUT_FILE;
+      }
+
+      if (!Files.isWritable(outputPath)) {
+        log.error("The output file is not writable");
         return ERROR_CANT_WRITE_OUTPUT_FILE;
       }
     }

--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -282,18 +282,10 @@ final class CLI implements Callable<Integer> {
     Path outputPath = null;
     if (output != null) {
       outputPath = output.getAbsoluteFile().toPath();
-      if(!Files.exists(outputPath)) {
-        Files.createFile(outputPath);
-      }
 
       // check if the output file parent directory doesn't exist or isn't writable
       if (!Files.exists(outputPath.getParent()) || !Files.isWritable(outputPath.getParent())) {
-        log.error("The output file parent directory doesn't exist");
-        return ERROR_CANT_WRITE_OUTPUT_FILE;
-      }
-
-      if (!Files.isWritable(outputPath)) {
-        log.error("The output file is not writable");
+        log.error("The output file parent directory doesn't exist or isn't writable");
         return ERROR_CANT_WRITE_OUTPUT_FILE;
       }
     }

--- a/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
@@ -125,17 +125,6 @@ final class CLITest {
   }
 
   @Test
-  void output_file_parent_dirs_created() throws IOException {
-    Path normalCodetf = Files.createTempDirectory("exists");
-    Path outputFile = normalCodetf.resolve("doesnt/exist/codetf.json");
-    String[] args =
-        new String[] {"--dont-exit", "--output", outputFile.toString(), workingRepoDir.toString()};
-    Runner.run(List.of(Cloud9Changer.class), args);
-    assertThat(Files.readString(fooJavaFile)).contains("cloud9");
-    assertThat(Files.exists(outputFile)).isTrue();
-  }
-
-  @Test
   void dry_run_works() throws IOException {
     Path normalCodetf = Files.createTempFile("normal", ".codetf");
     Path dryRunCodetf = Files.createTempFile("dryrun", ".codetf");

--- a/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/CLITest.java
@@ -61,6 +61,23 @@ final class CLITest {
                 List.of(barJavaFile.toAbsolutePath().toString())));
   }
 
+  @Test
+  void it_works_normally() throws IOException {
+    Path outputFile = Files.createTempFile("codetf", ".json");
+    String[] args =
+        new String[] {"--dont-exit", "--output", outputFile.toString(), workingRepoDir.toString()};
+    Runner.run(List.of(Cloud9Changer.class), args);
+    assertThat(Files.readString(fooJavaFile)).contains("cloud9");
+    assertThat(Files.exists(outputFile)).isTrue();
+  }
+
+  @Test
+  void it_works_without_output_file() throws IOException {
+    String[] args = new String[] {"--dont-exit", workingRepoDir.toString()};
+    Runner.run(List.of(Cloud9Changer.class), args);
+    assertThat(Files.readString(fooJavaFile)).contains("cloud9");
+  }
+
   /**
    * Runs the CLI with arguments that we know will cause it to fail, and asserts that the exit code
    * denotes failure and an error message is captured in the alternative stderr stream.
@@ -105,6 +122,17 @@ final class CLITest {
     Logger log = context.getLogger("myRootLogger");
     log.addAppender(appender);
     log.info("this is a test");
+  }
+
+  @Test
+  void output_file_parent_dirs_created() throws IOException {
+    Path normalCodetf = Files.createTempDirectory("exists");
+    Path outputFile = normalCodetf.resolve("doesnt/exist/codetf.json");
+    String[] args =
+        new String[] {"--dont-exit", "--output", outputFile.toString(), workingRepoDir.toString()};
+    Runner.run(List.of(Cloud9Changer.class), args);
+    assertThat(Files.readString(fooJavaFile)).contains("cloud9");
+    assertThat(Files.exists(outputFile)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
This is a two-fer since we're touching the same code:
- makes the CodeTF output file optional to meet the new spec
- works with relative output file