### PR TITLE
Avoid NPE when finding for file

### DIFF
--- a/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
+++ b/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
@@ -103,7 +103,7 @@ public final class MavenProvider implements ProjectProvider {
 
         Path parent = file.getParent();
 
-        while (parent != null && isDifferentFile(projectDir, parent)) {
+        while (parent != null && isProjectDirParentNullOrDifferentToParent(projectDir, parent)) {
           final Path pomPath = parent.resolve("pom.xml");
           if (Files.exists(pomPath)) {
             return Optional.of(pomPath);
@@ -115,7 +115,8 @@ public final class MavenProvider implements ProjectProvider {
       return Optional.empty();
     }
 
-    private boolean isDifferentFile(final Path projectDir, final Path parent) throws IOException {
+    private boolean isProjectDirParentNullOrDifferentToParent(
+        final Path projectDir, final Path parent) throws IOException {
       final Path projectDirParent = projectDir.getParent();
       return projectDirParent == null || !Files.isSameFile(projectDirParent, parent);
     }

--- a/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
+++ b/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
@@ -99,10 +99,12 @@ public final class MavenProvider implements ProjectProvider {
     @Override
     public Optional<Path> findForFile(final Path projectDir, final Path file) throws IOException {
 
-      if (projectDir != null && file != null && projectDir.getParent() != null) {
+      if (projectDir != null && file != null) {
+
         Path parent = file.getParent();
-        while (parent != null && !Files.isSameFile(projectDir.getParent(), parent)) {
-          Path pomPath = parent.resolve("pom.xml");
+
+        while (parent != null && isDifferentFile(projectDir, parent)) {
+          final Path pomPath = parent.resolve("pom.xml");
           if (Files.exists(pomPath)) {
             return Optional.of(pomPath);
           }
@@ -111,6 +113,11 @@ public final class MavenProvider implements ProjectProvider {
       }
 
       return Optional.empty();
+    }
+
+    private boolean isDifferentFile(final Path projectDir, final Path parent) throws IOException {
+      final Path projectDirParent = projectDir.getParent();
+      return projectDirParent == null || !Files.isSameFile(projectDirParent, parent);
     }
   }
 

--- a/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
+++ b/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
@@ -96,18 +96,22 @@ public final class MavenProvider implements ProjectProvider {
 
   @VisibleForTesting
   static class DefaultPomFileFinder implements PomFileFinder {
-    @Override
-    public Optional<Path> findForFile(final Path projectDir, final Path file) throws IOException {
-      Path parent = file.getParent();
-      while (parent != null && !Files.isSameFile(projectDir.getParent(), parent)) {
-        Path pomPath = parent.resolve("pom.xml");
-        if (Files.exists(pomPath)) {
-          return Optional.of(pomPath);
-        }
-        parent = parent.getParent();
+      @Override
+      public Optional<Path> findForFile(final Path projectDir, final Path file) throws IOException {
+
+          if(projectDir != null && file != null && projectDir.getParent() != null){
+              Path parent = file.getParent();
+              while (parent != null && !Files.isSameFile(projectDir.getParent(), parent)) {
+                  Path pomPath = parent.resolve("pom.xml");
+                  if (Files.exists(pomPath)) {
+                      return Optional.of(pomPath);
+                  }
+                  parent = parent.getParent();
+              }
+          }
+
+          return Optional.empty();
       }
-      return Optional.empty();
-    }
   }
 
   @Override

--- a/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
+++ b/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
@@ -96,22 +96,22 @@ public final class MavenProvider implements ProjectProvider {
 
   @VisibleForTesting
   static class DefaultPomFileFinder implements PomFileFinder {
-      @Override
-      public Optional<Path> findForFile(final Path projectDir, final Path file) throws IOException {
+    @Override
+    public Optional<Path> findForFile(final Path projectDir, final Path file) throws IOException {
 
-          if(projectDir != null && file != null && projectDir.getParent() != null){
-              Path parent = file.getParent();
-              while (parent != null && !Files.isSameFile(projectDir.getParent(), parent)) {
-                  Path pomPath = parent.resolve("pom.xml");
-                  if (Files.exists(pomPath)) {
-                      return Optional.of(pomPath);
-                  }
-                  parent = parent.getParent();
-              }
+      if (projectDir != null && file != null && projectDir.getParent() != null) {
+        Path parent = file.getParent();
+        while (parent != null && !Files.isSameFile(projectDir.getParent(), parent)) {
+          Path pomPath = parent.resolve("pom.xml");
+          if (Files.exists(pomPath)) {
+            return Optional.of(pomPath);
           }
-
-          return Optional.empty();
+          parent = parent.getParent();
+        }
       }
+
+      return Optional.empty();
+    }
   }
 
   @Override


### PR DESCRIPTION
Reported NPE is caused by the project directory's parent `projectDir.getParent()` in `!Files.isSameFile(projectDir.getParent(), parent)`

```
io.codemodder.plugins.maven.MavenProvider$DependencyUpdateException: Failure when updating dependencies
	at io.codemodder.plugins.maven.MavenProvider.updateDependencies(MavenProvider.java:125)
	at io.codemodder.DefaultCodemodExecutor.addPackages(DefaultCodemodExecutor.java:300)
	at io.codemodder.DefaultCodemodExecutor.updateFiles(DefaultCodemodExecutor.java:218)
	at io.codemodder.DefaultCodemodExecutor.lambda$execute$0(DefaultCodemodExecutor.java:149)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.NullPointerException: Cannot invoke "java.nio.file.Path.getFileSystem()" because "path" is null
	at java.base/java.nio.file.Files.provider(Files.java:105)
	at java.base/java.nio.file.Files.isSameFile(Files.java:1541)
	at io.codemodder.plugins.maven.MavenProvider$DefaultPomFileFinder.findForFile(MavenProvider.java:102)
	at io.codemodder.plugins.maven.DefaultPOMDependencyUpdater.isEmptyPomFile(DefaultPOMDependencyUpdater.java:128)
	at io.codemodder.plugins.maven.DefaultPOMDependencyUpdater.execute(DefaultPOMDependencyUpdater.java:75)
	at io.codemodder.plugins.maven.MavenProvider.updateDependencies(MavenProvider.java:121)
	... 8 more
```