### PR TITLE
Fix `AddClarifyingBracesCodemod` when handling else blocks cited

### DIFF
--- a/core-codemods/src/test/resources/add-clarifying-braces/Test.java.after
+++ b/core-codemods/src/test/resources/add-clarifying-braces/Test.java.after
@@ -27,4 +27,22 @@ public class Test
         doNonAdminStuff5();
    }
 
+   void handleEndingDoesntNeedAdjustment() {
+     if(!isAdmin)
+     doNonAdminStuff5();
+   }
+
+   void handleElse() {
+     System.out.println("a");
+     if(isAdmin) {
+       System.out.println("b");
+     }
+     else
+       {
+           System.out.println("c");
+       }
+       System.out.println("d");
+
+     System.out.println("e");
+   }
 }

--- a/core-codemods/src/test/resources/add-clarifying-braces/Test.java.before
+++ b/core-codemods/src/test/resources/add-clarifying-braces/Test.java.before
@@ -23,4 +23,20 @@ public class Test
         doNonAdminStuff5();
    }
 
+   void handleEndingDoesntNeedAdjustment() {
+     if(!isAdmin)
+     doNonAdminStuff5();
+   }
+
+   void handleElse() {
+     System.out.println("a");
+     if(isAdmin) {
+       System.out.println("b");
+     }
+     else
+       System.out.println("c");
+       System.out.println("d");
+
+     System.out.println("e");
+   }
 }


### PR DESCRIPTION
The codemod made an assumption that the `then` part of then `if` statement was what should be braced when this issue is reported. However, it could have reported the `else` section, which has slightly different logic. 

This change simplifies the code, adds new and missing test cases, and fixes the else case.