### PR TITLE
Sonar codemod for removing unused local variable

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/AddMissingOverrideCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/AddMissingOverrideCodemod.java
@@ -22,7 +22,7 @@ public final class AddMissingOverrideCodemod extends SonarPluginJavaParserChange
   @Inject
   public AddMissingOverrideCodemod(
       @ProvidedSonarScan(ruleId = "java:S1161") final RuleIssues issues) {
-    super(issues, SimpleName.class, RegionNodeMatcher.MATCHES_START);
+    super(issues, SimpleName.class);
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/AvoidImplicitPublicConstructorCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/AvoidImplicitPublicConstructorCodemod.java
@@ -27,7 +27,7 @@ public final class AvoidImplicitPublicConstructorCodemod
   @Inject
   public AvoidImplicitPublicConstructorCodemod(
       @ProvidedSonarScan(ruleId = "java:S1118") final RuleIssues issues) {
-    super(issues, SimpleName.class, RegionNodeMatcher.MATCHES_START);
+    super(issues, SimpleName.class);
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/FixRedundantStaticOnEnumCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/FixRedundantStaticOnEnumCodemod.java
@@ -20,7 +20,7 @@ public final class FixRedundantStaticOnEnumCodemod
   @Inject
   public FixRedundantStaticOnEnumCodemod(
       @ProvidedSonarScan(ruleId = "java:S2786") final RuleIssues issues) {
-    super(issues, EnumDeclaration.class, RegionNodeMatcher.MATCHES_START);
+    super(issues, EnumDeclaration.class);
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveRedundantVariableCreationCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveRedundantVariableCreationCodemod.java
@@ -22,7 +22,7 @@ public final class RemoveRedundantVariableCreationCodemod
   @Inject
   public RemoveRedundantVariableCreationCodemod(
       @ProvidedSonarScan(ruleId = "java:S1488") final RuleIssues issues) {
-    super(issues, ObjectCreationExpr.class, RegionNodeMatcher.MATCHES_START);
+    super(issues, ObjectCreationExpr.class);
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod.java
@@ -1,0 +1,36 @@
+package io.codemodder.codemods;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.SimpleName;
+import io.codemodder.*;
+import io.codemodder.providers.sonar.ProvidedSonarScan;
+import io.codemodder.providers.sonar.RuleIssues;
+import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
+import io.codemodder.providers.sonar.api.Issue;
+
+import javax.inject.Inject;
+
+/**   */
+@Codemod(
+    id = "sonar:java/remove-unused-local-variable-s1481",
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
+public final class RemoveUnusedLocalVariableCodemod extends SonarPluginJavaParserChanger<Node> {
+
+  @Inject
+  public RemoveUnusedLocalVariableCodemod(
+      @ProvidedSonarScan(ruleId = "java:S1481") final RuleIssues issues) {
+    super(issues, Node.class, RegionNodeMatcher.MATCHES_START);
+  }
+
+  @Override
+  public boolean onIssueFound(
+      final CodemodInvocationContext context,
+      final CompilationUnit cu,
+      final Node name,
+      final Issue issue) {
+
+    return true;
+  }
+}

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod.java
@@ -2,35 +2,62 @@ package io.codemodder.codemods;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.*;
 import io.codemodder.*;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
 import io.codemodder.providers.sonar.api.Issue;
-
+import java.util.Optional;
 import javax.inject.Inject;
 
-/**   */
+/**
+ * Codemod to remove unused local variables which expression is a variable or just a Literal
+ * expression like a single boolean, char, double, integer, long, null, string or a text block
+ * string. We are not considering create object expression, method call expressions, condition
+ * expressions, etc. because all of them have an expression node and that expression node could
+ * result in a method call expression where a process could be performed and deleting it could
+ * result on some unexpected behaviors.
+ */
 @Codemod(
     id = "sonar:java/remove-unused-local-variable-s1481",
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
     executionPriority = CodemodExecutionPriority.HIGH)
-public final class RemoveUnusedLocalVariableCodemod extends SonarPluginJavaParserChanger<Node> {
+public final class RemoveUnusedLocalVariableCodemod
+    extends SonarPluginJavaParserChanger<VariableDeclarator> {
 
   @Inject
   public RemoveUnusedLocalVariableCodemod(
       @ProvidedSonarScan(ruleId = "java:S1481") final RuleIssues issues) {
-    super(issues, Node.class, RegionNodeMatcher.MATCHES_START);
+    super(issues, VariableDeclarator.class, RegionNodeMatcher.MATCHES_START);
   }
 
   @Override
   public boolean onIssueFound(
       final CodemodInvocationContext context,
       final CompilationUnit cu,
-      final Node name,
+      final VariableDeclarator variableDeclarator,
       final Issue issue) {
 
-    return true;
+    final Optional<Expression> initializer = variableDeclarator.getInitializer();
+
+    if (initializer.isPresent()) {
+      final Expression initializerExpr = initializer.get();
+
+      if (initializerExpr instanceof LiteralExpr || initializerExpr instanceof NameExpr) {
+        final Optional<Node> variableDeclarationExprOptional = variableDeclarator.getParentNode();
+
+        if (variableDeclarationExprOptional.isPresent()) {
+          final VariableDeclarationExpr variableDeclarationExpr =
+              (VariableDeclarationExpr) variableDeclarationExprOptional.get();
+          variableDeclarationExpr.removeForced();
+        }
+      }
+
+      return true;
+    }
+
+    return false;
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod.java
@@ -2,6 +2,7 @@ package io.codemodder.codemods;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.*;
 import io.codemodder.*;
@@ -10,6 +11,7 @@ import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
 import io.codemodder.providers.sonar.api.Issue;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 /**
@@ -51,7 +53,16 @@ public final class RemoveUnusedLocalVariableCodemod
         if (variableDeclarationExprOptional.isPresent()) {
           final VariableDeclarationExpr variableDeclarationExpr =
               (VariableDeclarationExpr) variableDeclarationExprOptional.get();
-          variableDeclarationExpr.removeForced();
+
+          if (1 == variableDeclarationExpr.getVariables().size()) {
+            variableDeclarationExpr.removeForced();
+          } else {
+            final NodeList<VariableDeclarator> variables =
+                variableDeclarationExpr.getVariables().stream()
+                    .filter(variable -> !variable.equals(variableDeclarator))
+                    .collect(Collectors.toCollection(NodeList::new));
+            variableDeclarationExpr.setVariables(variables);
+          }
 
           return true;
         }

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod.java
@@ -30,7 +30,7 @@ public final class RemoveUnusedLocalVariableCodemod
   @Inject
   public RemoveUnusedLocalVariableCodemod(
       @ProvidedSonarScan(ruleId = "java:S1481") final RuleIssues issues) {
-    super(issues, VariableDeclarator.class, RegionNodeMatcher.MATCHES_START);
+    super(issues, VariableDeclarator.class);
   }
 
   @Override
@@ -52,10 +52,10 @@ public final class RemoveUnusedLocalVariableCodemod
           final VariableDeclarationExpr variableDeclarationExpr =
               (VariableDeclarationExpr) variableDeclarationExprOptional.get();
           variableDeclarationExpr.removeForced();
+
+          return true;
         }
       }
-
-      return true;
     }
 
     return false;

--- a/core-codemods/src/main/java/io/codemodder/codemods/SimplifyRestControllerAnnotationsCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SimplifyRestControllerAnnotationsCodemod.java
@@ -30,7 +30,7 @@ public final class SimplifyRestControllerAnnotationsCodemod
   @Inject
   public SimplifyRestControllerAnnotationsCodemod(
       @ProvidedSonarScan(ruleId = "java:S6833") final RuleIssues issues) {
-    super(issues, ClassOrInterfaceDeclaration.class, RegionNodeMatcher.MATCHES_START);
+    super(issues, ClassOrInterfaceDeclaration.class);
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/SubstituteReplaceAllCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SubstituteReplaceAllCodemod.java
@@ -19,7 +19,7 @@ public final class SubstituteReplaceAllCodemod extends SonarPluginJavaParserChan
   @Inject
   public SubstituteReplaceAllCodemod(
       @ProvidedSonarScan(ruleId = "java:S5361") final RuleIssues issues) {
-    super(issues, SimpleName.class, RegionNodeMatcher.MATCHES_START);
+    super(issues, SimpleName.class);
   }
 
   @Override

--- a/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/description.md
@@ -1,4 +1,4 @@
-TODO
+This change removes unused variables. Unused variables make the code harder to read, which will lead to confusion and bugs. We only remove variables that have no state-changing effects.
 
 Our changes look something like this:
 

--- a/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/description.md
@@ -3,9 +3,9 @@ TODO
 Our changes look something like this:
 
 ```diff
-    public LocaleResolver localeResolver() { 
--       SessionLocaleResolver localeResolver = new SessionLocaleResolver();
--       return localeResolver;
-+       return new SessionLocaleResolver();
-    }
+     catch (final UnsolvedSymbolException e) {
+-      String errorMessage = "An unexpected exception happened";
+       LOG.error("Problem resolving type of : {}", expr, e);
+       return false;
+     }
 ```

--- a/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/description.md
@@ -1,0 +1,11 @@
+TODO
+
+Our changes look something like this:
+
+```diff
+    public LocaleResolver localeResolver() { 
+-       SessionLocaleResolver localeResolver = new SessionLocaleResolver();
+-       return localeResolver;
++       return new SessionLocaleResolver();
+    }
+```

--- a/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/report.json
@@ -1,0 +1,7 @@
+{
+  "summary" : "",
+  "change" : "",
+  "references" : [
+    "https://rules.sonarsource.com/java/RSPEC-1481/"
+  ]
+}

--- a/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/report.json
@@ -1,6 +1,6 @@
 {
-  "summary" : "",
-  "change" : "",
+  "summary" : "Removed unused local variable (Sonar)",
+  "change" : "Removed unused local variable",
   "references" : [
     "https://rules.sonarsource.com/java/RSPEC-1481/"
   ]

--- a/core-codemods/src/test/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemodTest.java
@@ -1,0 +1,11 @@
+package io.codemodder.codemods;
+
+import io.codemodder.testutils.CodemodTestMixin;
+import io.codemodder.testutils.Metadata;
+
+@Metadata(
+    codemodType = RemoveUnusedLocalVariableCodemod.class,
+    testResourceDir = "remove-unused-local-variable-s1481",
+    renameTestFile = "src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+    dependencies = {})
+final class RemoveUnusedLocalVariableCodemodTest implements CodemodTestMixin {}

--- a/core-codemods/src/test/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemodTest.java
@@ -6,6 +6,7 @@ import io.codemodder.testutils.Metadata;
 @Metadata(
     codemodType = RemoveUnusedLocalVariableCodemod.class,
     testResourceDir = "remove-unused-local-variable-s1481",
-    renameTestFile = "src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+    renameTestFile =
+        "src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
     dependencies = {})
 final class RemoveUnusedLocalVariableCodemodTest implements CodemodTestMixin {}

--- a/core-codemods/src/test/resources/remove-unused-local-variable-s1481/Test.java.after
+++ b/core-codemods/src/test/resources/remove-unused-local-variable-s1481/Test.java.after
@@ -76,7 +76,6 @@ public abstract class AssignmentEndpoint implements Initializeable {
       int intSumMethod = 1 + intMethod(); // operation withMethod
       int intConstant = Integer.SIZE; //constant similar to var
       List<Integer> integerProcess = integers.stream().map(integer -> calculateOffsetAndPrint(integer)).toList(); //lambda
-      AssignmentEndpoint assignmentDup = assignment; // var
       List<Integer> intList = List.of(1, 2, 3, 4, 5); // method ???
       MyClass myClass = new MyClass(10); // constructor
       int y = (ten > 0) ? 10 : intMethod(); // ternary

--- a/core-codemods/src/test/resources/remove-unused-local-variable-s1481/Test.java.after
+++ b/core-codemods/src/test/resources/remove-unused-local-variable-s1481/Test.java.after
@@ -1,0 +1,138 @@
+/*
+ * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
+ * please see http://www.owasp.org/
+ * <p>
+ * Copyright (c) 2002 - 2017 Bruce Mayhew
+ * <p>
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ * <p>
+ * Getting Source ==============
+ * <p>
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
+ * projects.
+ * <p>
+ */
+
+package org.owasp.webgoat.container.assignments;
+
+import jnr.ffi.annotations.In;
+import lombok.Getter;
+import org.owasp.webgoat.container.i18n.PluginMessages;
+import org.owasp.webgoat.container.lessons.Initializeable;
+import org.owasp.webgoat.container.session.UserSessionData;
+import org.owasp.webgoat.container.session.WebSession;
+import org.owasp.webgoat.container.users.WebGoatUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.util.List;
+
+public abstract class AssignmentEndpoint implements Initializeable {
+
+  private WebSession webSession;
+  @Autowired private UserSessionData userSessionData;
+  @Getter @Autowired @Qualifier("mensajes")
+  private PluginMessages messages;
+
+  @Autowired
+  public AssignmentEndpoint(WebSession webSession){
+    this.webSession = webSession;
+  }
+
+  protected WebSession getWebSession() {
+    return webSession;
+  }
+
+  protected UserSessionData getUserSessionData() {
+    return userSessionData;
+  }
+
+  /**
+   * Convenience method for create a successful result:
+   *
+   * <p>- Assignment is set to solved - Feedback message is set to 'assignment.solved'
+   *
+   * <p>Of course you can overwrite these values in a specific lesson
+   *
+   * @return a builder for creating a result from a lesson
+   * @param assignment
+   */
+  protected AttackResult.AttackResultBuilder success(AssignmentEndpoint assignment) {
+      List<Integer> integers = List.of(1,2,3);
+      int ten = 10;
+
+      int integerResult = intMethod(); // method
+      int intSum = 1 + ten; // operation with var
+      int intSumMethod = 1 + intMethod(); // operation withMethod
+      int intConstant = Integer.SIZE; //constant similar to var
+      List<Integer> integerProcess = integers.stream().map(integer -> calculateOffsetAndPrint(integer)).toList(); //lambda
+      AssignmentEndpoint assignmentDup = assignment; // var
+      List<Integer> intList = List.of(1, 2, 3, 4, 5); // method ???
+      MyClass myClass = new MyClass(10); // constructor
+      int y = (ten > 0) ? 10 : intMethod(); // ternary
+
+    return AttackResult.builder(messages)
+        .lessonCompleted(true)
+        .attemptWasMade()
+        .feedback("assignment.solved")
+        .assignment(assignment);
+  }
+
+  /**
+   * Convenience method for create a failed result:
+   *
+   * <p>- Assignment is set to not solved - Feedback message is set to 'assignment.not.solved'
+   *
+   * <p>Of course you can overwrite these values in a specific lesson
+   *
+   * @return a builder for creating a result from a lesson
+   * @param assignment
+   */
+  protected AttackResult.AttackResultBuilder failed(AssignmentEndpoint assignment) {
+    return AttackResult.builder(messages)
+        .lessonCompleted(false)
+        .attemptWasMade()
+        .feedback("assignment.not.solved")
+        .assignment(assignment);
+  }
+
+  protected AttackResult.AttackResultBuilder informationMessage(AssignmentEndpoint assignment) {
+    return AttackResult.builder(messages).lessonCompleted(false).assignment(assignment);
+  }
+
+  private int intMethod () {
+      return 1;
+  }
+
+  private int calculateOffsetAndPrint(int a){
+      int offset = a + 1;
+      System.out.println(offset);
+      // someProcess
+      return offset;
+  }
+
+  @Override
+  public void initialize(WebGoatUser user) {}
+
+    private static class MyClass{
+        final int var;
+      MyClass(int var){
+       this.var = var;
+       process();
+      }
+
+      private void process(){
+          System.out.println("my class created with var : " + var);
+      }
+    }
+}

--- a/core-codemods/src/test/resources/remove-unused-local-variable-s1481/Test.java.after
+++ b/core-codemods/src/test/resources/remove-unused-local-variable-s1481/Test.java.after
@@ -79,6 +79,9 @@ public abstract class AssignmentEndpoint implements Initializeable {
       List<Integer> intList = List.of(1, 2, 3, 4, 5); // method ???
       MyClass myClass = new MyClass(10); // constructor
       int y = (ten > 0) ? 10 : intMethod(); // ternary
+      int used = 1, used1 = 10;
+
+      System.out.println(ten + used1 + used);
 
     return AttackResult.builder(messages)
         .lessonCompleted(true)

--- a/core-codemods/src/test/resources/remove-unused-local-variable-s1481/Test.java.before
+++ b/core-codemods/src/test/resources/remove-unused-local-variable-s1481/Test.java.before
@@ -82,6 +82,9 @@ public abstract class AssignmentEndpoint implements Initializeable {
       List<Integer> intList = List.of(1, 2, 3, 4, 5); // method ???
       MyClass myClass = new MyClass(10); // constructor
       int y = (ten > 0) ? 10 : intMethod(); // ternary
+      int used = 1, unused = 0, used1 = 10;
+
+      System.out.println(ten + used1 + used);
 
     return AttackResult.builder(messages)
         .lessonCompleted(true)

--- a/core-codemods/src/test/resources/remove-unused-local-variable-s1481/Test.java.before
+++ b/core-codemods/src/test/resources/remove-unused-local-variable-s1481/Test.java.before
@@ -1,0 +1,140 @@
+/*
+ * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
+ * please see http://www.owasp.org/
+ * <p>
+ * Copyright (c) 2002 - 2017 Bruce Mayhew
+ * <p>
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ * <p>
+ * Getting Source ==============
+ * <p>
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
+ * projects.
+ * <p>
+ */
+
+package org.owasp.webgoat.container.assignments;
+
+import jnr.ffi.annotations.In;
+import lombok.Getter;
+import org.owasp.webgoat.container.i18n.PluginMessages;
+import org.owasp.webgoat.container.lessons.Initializeable;
+import org.owasp.webgoat.container.session.UserSessionData;
+import org.owasp.webgoat.container.session.WebSession;
+import org.owasp.webgoat.container.users.WebGoatUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.util.List;
+
+public abstract class AssignmentEndpoint implements Initializeable {
+
+  private WebSession webSession;
+  @Autowired private UserSessionData userSessionData;
+  @Getter @Autowired @Qualifier("mensajes")
+  private PluginMessages messages;
+
+  @Autowired
+  public AssignmentEndpoint(WebSession webSession){
+    this.webSession = webSession;
+  }
+
+  protected WebSession getWebSession() {
+    return webSession;
+  }
+
+  protected UserSessionData getUserSessionData() {
+    return userSessionData;
+  }
+
+  /**
+   * Convenience method for create a successful result:
+   *
+   * <p>- Assignment is set to solved - Feedback message is set to 'assignment.solved'
+   *
+   * <p>Of course you can overwrite these values in a specific lesson
+   *
+   * @return a builder for creating a result from a lesson
+   * @param assignment
+   */
+  protected AttackResult.AttackResultBuilder success(AssignmentEndpoint assignment) {
+      List<Integer> integers = List.of(1,2,3);
+      int ten = 10;
+
+      String msg = ""; // primite REMOVED
+      int integerResult = intMethod(); // method
+      int intSum = 1 + ten; // operation with var
+      int intSumMethod = 1 + intMethod(); // operation withMethod
+      int zero = 0; // primitive
+      int intConstant = Integer.SIZE; //constant similar to var
+      List<Integer> integerProcess = integers.stream().map(integer -> calculateOffsetAndPrint(integer)).toList(); //lambda
+      AssignmentEndpoint assignmentDup = assignment; // var
+      List<Integer> intList = List.of(1, 2, 3, 4, 5); // method ???
+      MyClass myClass = new MyClass(10); // constructor
+      int y = (ten > 0) ? 10 : intMethod(); // ternary
+
+    return AttackResult.builder(messages)
+        .lessonCompleted(true)
+        .attemptWasMade()
+        .feedback("assignment.solved")
+        .assignment(assignment);
+  }
+
+  /**
+   * Convenience method for create a failed result:
+   *
+   * <p>- Assignment is set to not solved - Feedback message is set to 'assignment.not.solved'
+   *
+   * <p>Of course you can overwrite these values in a specific lesson
+   *
+   * @return a builder for creating a result from a lesson
+   * @param assignment
+   */
+  protected AttackResult.AttackResultBuilder failed(AssignmentEndpoint assignment) {
+    return AttackResult.builder(messages)
+        .lessonCompleted(false)
+        .attemptWasMade()
+        .feedback("assignment.not.solved")
+        .assignment(assignment);
+  }
+
+  protected AttackResult.AttackResultBuilder informationMessage(AssignmentEndpoint assignment) {
+    return AttackResult.builder(messages).lessonCompleted(false).assignment(assignment);
+  }
+
+  private int intMethod () {
+      return 1;
+  }
+
+  private int calculateOffsetAndPrint(int a){
+      int offset = a + 1;
+      System.out.println(offset);
+      // someProcess
+      return offset;
+  }
+
+  @Override
+  public void initialize(WebGoatUser user) {}
+
+    private static class MyClass{
+        final int var;
+      MyClass(int var){
+       this.var = var;
+       process();
+      }
+
+      private void process(){
+          System.out.println("my class created with var : " + var);
+      }
+    }
+}

--- a/core-codemods/src/test/resources/remove-unused-local-variable-s1481/sonar-issues.json
+++ b/core-codemods/src/test/resources/remove-unused-local-variable-s1481/sonar-issues.json
@@ -1,15 +1,50 @@
 {
-  "total": 11,
+  "total": 12,
   "p": 1,
   "ps": 500,
   "paging": {
     "pageIndex": 1,
     "pageSize": 500,
-    "total": 11
+    "total": 12
   },
-  "effortTotal": 55,
-  "debtTotal": 55,
+  "effortTotal": 60,
+  "debtTotal": 60,
   "issues": [
+    {
+      "key": "AYxkqUZwlAj1v1V7lso4",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 85,
+      "hash": "87a642a820b265aca0a8f400482b7480",
+      "textRange": {
+        "startLine": 85,
+        "endLine": 85,
+        "startOffset": 20,
+        "endOffset": 26
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"unused\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-13T20:28:16+0100",
+      "updateDate": "2023-12-13T20:28:16+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    },
     {
       "key": "AYxfqdgz7I9_CfiZFZTk",
       "rule": "java:S1481",
@@ -33,7 +68,7 @@
         "unused"
       ],
       "creationDate": "2023-12-12T21:09:57+0100",
-      "updateDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-13T21:16:17+0100",
       "type": "CODE_SMELL",
       "organization": "nahsra",
       "cleanCodeAttribute": "CLEAR",

--- a/core-codemods/src/test/resources/remove-unused-local-variable-s1481/sonar-issues.json
+++ b/core-codemods/src/test/resources/remove-unused-local-variable-s1481/sonar-issues.json
@@ -1,0 +1,427 @@
+{
+  "total": 11,
+  "p": 1,
+  "ps": 500,
+  "paging": {
+    "pageIndex": 1,
+    "pageSize": 500,
+    "total": 11
+  },
+  "effortTotal": 55,
+  "debtTotal": 55,
+  "issues": [
+    {
+      "key": "AYxfqdgz7I9_CfiZFZTk",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 74,
+      "hash": "57b04e72050d5407745f21143852e52c",
+      "textRange": {
+        "startLine": 74,
+        "endLine": 74,
+        "startOffset": 13,
+        "endOffset": 16
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"msg\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-12T21:09:57+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    },
+    {
+      "key": "AYxfqdgz7I9_CfiZFZTl",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 75,
+      "hash": "7be5f0f8192dc050a2488c537f79d3ab",
+      "textRange": {
+        "startLine": 75,
+        "endLine": 75,
+        "startOffset": 10,
+        "endOffset": 23
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"integerResult\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-12T21:09:57+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    },
+    {
+      "key": "AYxfqdgz7I9_CfiZFZTm",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 76,
+      "hash": "b062111d31d34946982756ffb41ecaa5",
+      "textRange": {
+        "startLine": 76,
+        "endLine": 76,
+        "startOffset": 10,
+        "endOffset": 16
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"intSum\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-12T21:09:57+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    },
+    {
+      "key": "AYxfqdgz7I9_CfiZFZTn",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 77,
+      "hash": "9824cb04353e5a14c86e572d1d860e1c",
+      "textRange": {
+        "startLine": 77,
+        "endLine": 77,
+        "startOffset": 10,
+        "endOffset": 22
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"intSumMethod\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-12T21:09:57+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    },
+    {
+      "key": "AYxfqdgz7I9_CfiZFZTo",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 78,
+      "hash": "d11b9e1c8550b43b62aa34c26772b1b6",
+      "textRange": {
+        "startLine": 78,
+        "endLine": 78,
+        "startOffset": 10,
+        "endOffset": 14
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"zero\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-12T21:09:57+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    },
+    {
+      "key": "AYxfqdgz7I9_CfiZFZTp",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 79,
+      "hash": "1b1a428b2510f91a74b9d7324359912e",
+      "textRange": {
+        "startLine": 79,
+        "endLine": 79,
+        "startOffset": 10,
+        "endOffset": 21
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"intConstant\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-12T21:09:57+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    },
+    {
+      "key": "AYxfqdgz7I9_CfiZFZTq",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 80,
+      "hash": "2f4800dcc04342932cdf5df1533d3528",
+      "textRange": {
+        "startLine": 80,
+        "endLine": 80,
+        "startOffset": 20,
+        "endOffset": 34
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"integerProcess\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-12T21:09:57+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    },
+    {
+      "key": "AYxfqdgz7I9_CfiZFZTr",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 81,
+      "hash": "0e1a5206955f48bbf7a316c6ad215c0d",
+      "textRange": {
+        "startLine": 81,
+        "endLine": 81,
+        "startOffset": 25,
+        "endOffset": 38
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"assignmentDup\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-12T21:09:57+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    },
+    {
+      "key": "AYxfqdgz7I9_CfiZFZTs",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 82,
+      "hash": "37589ec227cf543e3efd9dda0b6c219f",
+      "textRange": {
+        "startLine": 82,
+        "endLine": 82,
+        "startOffset": 20,
+        "endOffset": 27
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"intList\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-12T21:09:57+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    },
+    {
+      "key": "AYxfqdgz7I9_CfiZFZTt",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 83,
+      "hash": "a6ab3ea4489f290e435446132430563d",
+      "textRange": {
+        "startLine": 83,
+        "endLine": 83,
+        "startOffset": 14,
+        "endOffset": 21
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"myClass\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-12T21:09:57+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    },
+    {
+      "key": "AYxfqdgz7I9_CfiZFZTu",
+      "rule": "java:S1481",
+      "severity": "MINOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 84,
+      "hash": "f017a84a6349f059a30ae8c2556df9f2",
+      "textRange": {
+        "startLine": 84,
+        "endLine": 84,
+        "startOffset": 10,
+        "endOffset": 11
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Remove this unused \"y\" local variable.",
+      "effort": "5min",
+      "debt": "5min",
+      "tags": [
+        "unused"
+      ],
+      "creationDate": "2023-12-12T21:09:57+0100",
+      "updateDate": "2023-12-12T21:09:57+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "LOW"
+        }
+      ]
+    }
+  ],
+  "components": [
+    {
+      "organization": "nahsra",
+      "key": "nahsra_WebGoat_10_23:src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "uuid": "AYvtrjqJLCzGLicz7Abq",
+      "enabled": true,
+      "qualifier": "FIL",
+      "name": "AssignmentEndpoint.java",
+      "longName": "src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java",
+      "path": "src/main/java/org/owasp/webgoat/container/assignments/AssignmentEndpoint.java"
+    },
+    {
+      "organization": "nahsra",
+      "key": "nahsra_WebGoat_10_23",
+      "uuid": "AYvtqxxxzY4Rr5NHn4Om",
+      "enabled": true,
+      "qualifier": "TRK",
+      "name": "WebGoat_10_23",
+      "longName": "WebGoat_10_23"
+    }
+  ],
+  "organizations": [
+    {
+      "key": "nahsra",
+      "name": "Arshan Dabirsiaghi"
+    }
+  ],
+  "facets": []
+}

--- a/plugins/codemodder-plugin-sonar/src/main/java/io/codemodder/providers/sonar/SonarPluginJavaParserChanger.java
+++ b/plugins/codemodder-plugin-sonar/src/main/java/io/codemodder/providers/sonar/SonarPluginJavaParserChanger.java
@@ -26,11 +26,10 @@ public abstract class SonarPluginJavaParserChanger<T extends Node> extends JavaP
     this.regionNodeMatcher = regionNodeMatcher;
   }
 
-    protected SonarPluginJavaParserChanger(
-            final RuleIssues ruleIssues,
-            final Class<? extends Node> nodeType) {
-        this(ruleIssues, nodeType, RegionNodeMatcher.MATCHES_START);
-    }
+  protected SonarPluginJavaParserChanger(
+      final RuleIssues ruleIssues, final Class<? extends Node> nodeType) {
+    this(ruleIssues, nodeType, RegionNodeMatcher.MATCHES_START);
+  }
 
   protected SonarPluginJavaParserChanger(
       final RuleIssues ruleIssues,

--- a/plugins/codemodder-plugin-sonar/src/main/java/io/codemodder/providers/sonar/SonarPluginJavaParserChanger.java
+++ b/plugins/codemodder-plugin-sonar/src/main/java/io/codemodder/providers/sonar/SonarPluginJavaParserChanger.java
@@ -26,6 +26,12 @@ public abstract class SonarPluginJavaParserChanger<T extends Node> extends JavaP
     this.regionNodeMatcher = regionNodeMatcher;
   }
 
+    protected SonarPluginJavaParserChanger(
+            final RuleIssues ruleIssues,
+            final Class<? extends Node> nodeType) {
+        this(ruleIssues, nodeType, RegionNodeMatcher.MATCHES_START);
+    }
+
   protected SonarPluginJavaParserChanger(
       final RuleIssues ruleIssues,
       final Class<? extends Node> nodeType,


### PR DESCRIPTION
Codemod to remove unused local variables which expression is a variable (`NameExpr`) or just a Literal expression like a single boolean, char, double, integer, long, null, string or a text block string. We are not considering create object expression, method call expressions, condition expressions, etc. because all of them have an expression node and that expression node could result in a method call expression where a process could be performed and deleting it could result on some unexpected behaviors.

Examples of unused `LiteralExpr` : 
* String msg = "my message"
* char myChar = 'c';
* int ten = 10;
* etc

sonar cloud report example: https://sonarcloud.io/project/issues?fileUuids=AYvtrjqJLCzGLicz7Abq&resolved=false&types=CODE_SMELL&id=nahsra_WebGoat_10_23

reference: https://rules.sonarsource.com/java/RSPEC-1481/