### PR TITLE
Sonar codemod to replace `Stream.collect(Collectors.toList())` with Java 16 + `Stream.toList()`

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java
@@ -69,7 +69,7 @@ public final class MavenSecureURLCodemod extends SarifPluginRawFileChanger {
     Set<Integer> linesAffected = xmlChange.linesAffected();
 
     List<CodemodChange> allWeaves =
-        linesAffected.stream().map(CodemodChange::from).toList();
+        linesAffected.stream().map(CodemodChange::from).collect(Collectors.toList());
 
     // overwrite the previous web.xml with the new one
     Files.copy(xmlChange.transformedXml(), file, StandardCopyOption.REPLACE_EXISTING);

--- a/core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java
@@ -69,7 +69,7 @@ public final class MavenSecureURLCodemod extends SarifPluginRawFileChanger {
     Set<Integer> linesAffected = xmlChange.linesAffected();
 
     List<CodemodChange> allWeaves =
-        linesAffected.stream().map(CodemodChange::from).collect(Collectors.toList());
+        linesAffected.stream().map(CodemodChange::from).toList();
 
     // overwrite the previous web.xml with the new one
     Files.copy(xmlChange.transformedXml(), file, StandardCopyOption.REPLACE_EXISTING);

--- a/core-codemods/src/main/java/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod.java
@@ -1,0 +1,52 @@
+package io.codemodder.codemods;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import io.codemodder.Codemod;
+import io.codemodder.CodemodExecutionPriority;
+import io.codemodder.CodemodInvocationContext;
+import io.codemodder.ReviewGuidance;
+import io.codemodder.providers.sonar.ProvidedSonarScan;
+import io.codemodder.providers.sonar.RuleIssues;
+import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
+import io.codemodder.providers.sonar.api.Issue;
+import java.util.Optional;
+import javax.inject.Inject;
+
+/** A codemod for replacing 'Stream.collect(Collectors.toList())' with 'Stream.toList()' */
+@Codemod(
+    id = "sonar:java/replace-stream-collectors-to-list-s6204",
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
+public final class ReplaceStreamCollectorsToListCodemod
+    extends SonarPluginJavaParserChanger<MethodCallExpr> {
+
+  @Inject
+  public ReplaceStreamCollectorsToListCodemod(
+      @ProvidedSonarScan(ruleId = "java:S6204") final RuleIssues issues) {
+    super(issues, MethodCallExpr.class);
+  }
+
+  @Override
+  public boolean onIssueFound(
+      final CodemodInvocationContext context,
+      final CompilationUnit cu,
+      final MethodCallExpr methodCallExpr,
+      final Issue issue) {
+
+    final Optional<Node> collectMethodExprOptional = methodCallExpr.getParentNode();
+
+    if (collectMethodExprOptional.isEmpty()) {
+      return false;
+    }
+
+    final MethodCallExpr collectMethodExpr = (MethodCallExpr) collectMethodExprOptional.get();
+    collectMethodExpr.setName("toList");
+
+    collectMethodExpr.setArguments(new NodeList<>());
+
+    return true;
+  }
+}

--- a/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/description.md
@@ -1,0 +1,7 @@
+TODO
+
+Our changes look something like this:
+
+```diff
+
+```

--- a/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/description.md
@@ -3,7 +3,6 @@ This change modernizes the a stream's `List` creation to be driven from the simp
 Our changes look something like this:
 
 ```diff
-     List<CodemodChange> allWeaves =
--        linesAffected.stream().map(CodemodChange::from).collect(Collectors.toList());
-+        linesAffected.stream().map(CodemodChange::from).toList();
+- List<Integer> numbers = someStream.collect(Collectors.toList());
++ List<Integer> numbers = someStream.toList();
 ```

--- a/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/description.md
@@ -3,5 +3,7 @@ TODO
 Our changes look something like this:
 
 ```diff
-
+     List<CodemodChange> allWeaves =
+-        linesAffected.stream().map(CodemodChange::from).collect(Collectors.toList());
++        linesAffected.stream().map(CodemodChange::from).toList();
 ```

--- a/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/description.md
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/description.md
@@ -1,4 +1,4 @@
-TODO
+This change modernizes the a stream's `List` creation to be driven from the simple, and more readable [`Stream#toList()`](https://docs.oracle.com/javase/16/docs/api/java.base/java/util/stream/Collectors.html#toList()) method.
 
 Our changes look something like this:
 

--- a/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/report.json
@@ -1,0 +1,7 @@
+{
+  "summary" : "Replaced `Stream.collect(Collectors.toList())` with `Stream.toList()` (Sonar)",
+  "change" : "Replaced `Stream.collect(Collectors.toList())` with `Stream.toList()`.",
+  "references" : [
+    "https://rules.sonarsource.com/java/RSPEC-6204/"
+  ]
+}

--- a/core-codemods/src/test/java/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemodTest.java
+++ b/core-codemods/src/test/java/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemodTest.java
@@ -1,0 +1,12 @@
+package io.codemodder.codemods;
+
+import io.codemodder.testutils.CodemodTestMixin;
+import io.codemodder.testutils.Metadata;
+
+@Metadata(
+    codemodType = ReplaceStreamCollectorsToListCodemod.class,
+    testResourceDir = "replace-collectors-toList-s6204",
+    renameTestFile =
+        "core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java",
+    dependencies = {})
+final class ReplaceStreamCollectorsToListCodemodTest implements CodemodTestMixin {}

--- a/core-codemods/src/test/resources/replace-collectors-toList-s6204/Test.java.after
+++ b/core-codemods/src/test/resources/replace-collectors-toList-s6204/Test.java.after
@@ -1,0 +1,103 @@
+package io.codemodder.codemods;
+
+import com.contrastsecurity.sarif.Result;
+import io.codemodder.*;
+import io.codemodder.providers.sarif.codeql.ProvidedCodeQLScan;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.XMLEvent;
+import org.dom4j.DocumentException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+/** Fixes issues reported under the id "java/maven/non-https-url". */
+@Codemod(
+    id = "codeql:java/maven/non-https-url",
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
+public final class MavenSecureURLCodemod extends SarifPluginRawFileChanger {
+
+  private final XPathStreamProcessor processor;
+
+  @Inject
+  MavenSecureURLCodemod(
+      @ProvidedCodeQLScan(ruleId = "java/maven/non-https-url") final RuleSarif sarif,
+      final XPathStreamProcessor processor) {
+    super(sarif);
+    this.processor = Objects.requireNonNull(processor);
+  }
+
+  @Override
+  public List<CodemodChange> onFileFound(
+      final CodemodInvocationContext context, final List<Result> results) {
+    try {
+      return processXml(context.path());
+    } catch (SAXException | DocumentException | IOException | XMLStreamException e) {
+      LOG.error("Problem transforming xml file: {}", context.path());
+      return List.of();
+    }
+  }
+
+  private List<CodemodChange> processXml(final Path file)
+      throws SAXException, IOException, DocumentException, XMLStreamException {
+    Optional<XPathStreamProcessChange> change =
+        processor.process(
+            file,
+            "//*[local-name()='repository']/*[local-name()='url'] |"
+                + " //*[local-name()='pluginRepository']/*[local-name()='url'] |"
+                + " //*[local-name()='snapshotRepository']/*[local-name()='url']",
+            MavenSecureURLCodemod::handle);
+
+    if (change.isEmpty()) {
+      return List.of();
+    }
+
+    XPathStreamProcessChange xmlChange = change.get();
+    Set<Integer> linesAffected = xmlChange.linesAffected();
+
+    List<CodemodChange> allWeaves =
+        linesAffected.stream().map(CodemodChange::from).toList();
+
+    // overwrite the previous web.xml with the new one
+    Files.copy(xmlChange.transformedXml(), file, StandardCopyOption.REPLACE_EXISTING);
+    return allWeaves;
+  }
+
+  /*
+   * Change contents of the {@code url} tag if it it uses an insecure protocol.
+   */
+  private static void handle(
+      final XMLEventReader xmlEventReader,
+      final XMLEventWriter xmlEventWriter,
+      final XMLEvent currentEvent)
+      throws XMLStreamException {
+    final var xmlEventFactory = XMLEventFactory.newInstance();
+    xmlEventWriter.add(currentEvent);
+    final var nextEvent = xmlEventReader.nextEvent();
+    final var url = nextEvent.asCharacters().getData();
+    if (url.startsWith("http:")) {
+      final var fixed = "https:" + url.substring(5);
+      xmlEventWriter.add(xmlEventFactory.createCharacters(fixed));
+    } else if (url.startsWith("ftp:")) {
+      final var fixed = "ftps:" + url.substring(4);
+      xmlEventWriter.add(xmlEventFactory.createCharacters(fixed));
+    } else {
+      xmlEventWriter.add(nextEvent);
+    }
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(MavenSecureURLCodemod.class);
+}

--- a/core-codemods/src/test/resources/replace-collectors-toList-s6204/Test.java.before
+++ b/core-codemods/src/test/resources/replace-collectors-toList-s6204/Test.java.before
@@ -1,0 +1,103 @@
+package io.codemodder.codemods;
+
+import com.contrastsecurity.sarif.Result;
+import io.codemodder.*;
+import io.codemodder.providers.sarif.codeql.ProvidedCodeQLScan;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.XMLEvent;
+import org.dom4j.DocumentException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+/** Fixes issues reported under the id "java/maven/non-https-url". */
+@Codemod(
+    id = "codeql:java/maven/non-https-url",
+    reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
+    executionPriority = CodemodExecutionPriority.HIGH)
+public final class MavenSecureURLCodemod extends SarifPluginRawFileChanger {
+
+  private final XPathStreamProcessor processor;
+
+  @Inject
+  MavenSecureURLCodemod(
+      @ProvidedCodeQLScan(ruleId = "java/maven/non-https-url") final RuleSarif sarif,
+      final XPathStreamProcessor processor) {
+    super(sarif);
+    this.processor = Objects.requireNonNull(processor);
+  }
+
+  @Override
+  public List<CodemodChange> onFileFound(
+      final CodemodInvocationContext context, final List<Result> results) {
+    try {
+      return processXml(context.path());
+    } catch (SAXException | DocumentException | IOException | XMLStreamException e) {
+      LOG.error("Problem transforming xml file: {}", context.path());
+      return List.of();
+    }
+  }
+
+  private List<CodemodChange> processXml(final Path file)
+      throws SAXException, IOException, DocumentException, XMLStreamException {
+    Optional<XPathStreamProcessChange> change =
+        processor.process(
+            file,
+            "//*[local-name()='repository']/*[local-name()='url'] |"
+                + " //*[local-name()='pluginRepository']/*[local-name()='url'] |"
+                + " //*[local-name()='snapshotRepository']/*[local-name()='url']",
+            MavenSecureURLCodemod::handle);
+
+    if (change.isEmpty()) {
+      return List.of();
+    }
+
+    XPathStreamProcessChange xmlChange = change.get();
+    Set<Integer> linesAffected = xmlChange.linesAffected();
+
+    List<CodemodChange> allWeaves =
+        linesAffected.stream().map(CodemodChange::from).collect(Collectors.toList());
+
+    // overwrite the previous web.xml with the new one
+    Files.copy(xmlChange.transformedXml(), file, StandardCopyOption.REPLACE_EXISTING);
+    return allWeaves;
+  }
+
+  /*
+   * Change contents of the {@code url} tag if it it uses an insecure protocol.
+   */
+  private static void handle(
+      final XMLEventReader xmlEventReader,
+      final XMLEventWriter xmlEventWriter,
+      final XMLEvent currentEvent)
+      throws XMLStreamException {
+    final var xmlEventFactory = XMLEventFactory.newInstance();
+    xmlEventWriter.add(currentEvent);
+    final var nextEvent = xmlEventReader.nextEvent();
+    final var url = nextEvent.asCharacters().getData();
+    if (url.startsWith("http:")) {
+      final var fixed = "https:" + url.substring(5);
+      xmlEventWriter.add(xmlEventFactory.createCharacters(fixed));
+    } else if (url.startsWith("ftp:")) {
+      final var fixed = "ftps:" + url.substring(4);
+      xmlEventWriter.add(xmlEventFactory.createCharacters(fixed));
+    } else {
+      xmlEventWriter.add(nextEvent);
+    }
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(MavenSecureURLCodemod.class);
+}

--- a/core-codemods/src/test/resources/replace-collectors-toList-s6204/sonar-issues.json
+++ b/core-codemods/src/test/resources/replace-collectors-toList-s6204/sonar-issues.json
@@ -1,0 +1,79 @@
+{
+  "total": 1,
+  "p": 1,
+  "ps": 500,
+  "paging": {
+    "pageIndex": 1,
+    "pageSize": 500,
+    "total": 1
+  },
+  "effortTotal": 5,
+  "debtTotal": 5,
+  "issues": [
+    {
+      "key": "AYu2g5Hn97lOFaqEjR0v",
+      "rule": "java:S6204",
+      "severity": "MAJOR",
+      "component": "pixee_codemodder-java:core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java",
+      "project": "pixee_codemodder-java",
+      "line": 72,
+      "hash": "dde477e51d696ed510a0ade800320f23",
+      "textRange": {
+        "startLine": 72,
+        "endLine": 72,
+        "startOffset": 64,
+        "endOffset": 83
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Replace this usage of 'Stream.collect(Collectors.toList())' with 'Stream.toList()'",
+      "effort": "5min",
+      "debt": "5min",
+      "assignee": "nahsra@github",
+      "author": "arshan.dabirsiaghi@gmail.com",
+      "tags": [
+        "java16"
+      ],
+      "creationDate": "2023-07-28T17:02:08+0200",
+      "updateDate": "2023-11-10T00:55:25+0100",
+      "type": "CODE_SMELL",
+      "organization": "pixee",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "MEDIUM"
+        }
+      ]
+    }
+  ],
+  "components": [
+    {
+      "organization": "pixee",
+      "key": "pixee_codemodder-java",
+      "uuid": "AYu2gu7gBsP_nwHMid1L",
+      "enabled": true,
+      "qualifier": "TRK",
+      "name": "codemodder-java",
+      "longName": "codemodder-java"
+    },
+    {
+      "organization": "pixee",
+      "key": "pixee_codemodder-java:core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java",
+      "uuid": "AYu2g4-e97lOFaqEjRrD",
+      "enabled": true,
+      "qualifier": "FIL",
+      "name": "MavenSecureURLCodemod.java",
+      "longName": "core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java",
+      "path": "core-codemods/src/main/java/io/codemodder/codemods/MavenSecureURLCodemod.java"
+    }
+  ],
+  "organizations": [
+    {
+      "key": "pixee",
+      "name": "Pixee"
+    }
+  ],
+  "facets": []
+}


### PR DESCRIPTION
Since Java 16 there is now a better variant to produce an unmodifiable list directly from a stream: Stream.toList().

Reference https://rules.sonarsource.com/java/RSPEC-6204/

Example: https://sonarcloud.io/project/issues?open=AYu2g5Hn97lOFaqEjR0v&id=pixee_codemodder-java