### PR TITLE
Move switch default codemod out of default list

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/DefaultCodemods.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/DefaultCodemods.java
@@ -29,7 +29,6 @@ public final class DefaultCodemods {
         JSPScriptletXSSCodemod.class,
         LimitReadlineCodemod.class,
         MavenSecureURLCodemod.class,
-        MoveSwitchDefaultCaseLastCodemod.class,
         OutputResourceLeakCodemod.class,
         PreventFileWriterLeakWithFilesCodemod.class,
         RandomizeSeedCodemod.class,

--- a/core-codemods/src/main/java/io/codemodder/codemods/MoveSwitchDefaultCaseLastCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/MoveSwitchDefaultCaseLastCodemod.java
@@ -11,7 +11,9 @@ import javax.inject.Inject;
 
 /**
  * A codemod for moving the "default" case to last in switch statements. This codemod is not
- * currently in the default set because it
+ * currently in the default set because it could conceivably change behavior when other case
+ * statements fall through to it. It should be improved to only move if the previous case
+ * does not fall through.
  */
 @Codemod(
     id = "pixee:java/move-switch-default-last",

--- a/core-codemods/src/main/java/io/codemodder/codemods/MoveSwitchDefaultCaseLastCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/MoveSwitchDefaultCaseLastCodemod.java
@@ -12,8 +12,8 @@ import javax.inject.Inject;
 /**
  * A codemod for moving the "default" case to last in switch statements. This codemod is not
  * currently in the default set because it could conceivably change behavior when other case
- * statements fall through to it. It should be improved to only move if the previous case
- * does not fall through.
+ * statements fall through to it. It should be improved to only move if the previous case does not
+ * fall through.
  */
 @Codemod(
     id = "pixee:java/move-switch-default-last",


### PR DESCRIPTION
This codemod can change program behavior if the previous case statements fall through to it. Until this issue is resolved, this should not be a core/reference codemod.