### PR TITLE
Short circuit composed codemod execution if needed

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/CompositeJavaParserChanger.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CompositeJavaParserChanger.java
@@ -35,4 +35,9 @@ public abstract class CompositeJavaParserChanger extends JavaParserChanger {
     changers.forEach(changer -> changes.addAll(changer.visit(context, cu)));
     return changes;
   }
+
+  @Override
+  public boolean shouldRun() {
+    return changers.stream().anyMatch(CodeChanger::shouldRun);
+  }
 }


### PR DESCRIPTION
We should only run a composite codemod if any of the composed codemods should run. This logic was previously missing, so these codemods were running, regardless of whether any results were found in pre-processing.