### PR TITLE
:sparkles: Exclude test fixtures by default from codemod modification

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -618,6 +618,7 @@ final class CLI implements Callable<Integer> {
   private static final List<String> defaultPathExcludes =
       List.of(
           "**/test/**",
+          "**/testFixtures/**",
           "**/*Test.java",
           "**/intTest/**",
           "**/tests/**",


### PR DESCRIPTION
this directory is a standard source set for Gradle projects that use the `java-test-fixtures` plugin: https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures