### PR TITLE
Updated toolkit to 1.1.2

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/DependencyGAV.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DependencyGAV.java
@@ -160,7 +160,7 @@ public interface DependencyGAV {
         group, artifact, version, justification, license, repositoryUrl, noTransitiveDependencies);
   }
 
-  String JAVA_SECURITY_TOOLKIT_VERSION = "1.1.1";
+  String JAVA_SECURITY_TOOLKIT_VERSION = "1.1.2";
   String JAVA_SECURITY_TOOLKIT_GAV =
       "io.github.pixee:java-security-toolkit:" + JAVA_SECURITY_TOOLKIT_VERSION;
 


### PR DESCRIPTION
This change updates the version of the Java Security Toolkit for its upcoming release.