### PR TITLE
Add signing requirement for all situations

### DIFF
--- a/gradle/build-plugins/src/main/kotlin/io.codemodder.maven-publish.gradle.kts
+++ b/gradle/build-plugins/src/main/kotlin/io.codemodder.maven-publish.gradle.kts
@@ -26,8 +26,6 @@ signing {
         val signingKey: String? by project
         val signingPassword: String? by project
         useInMemoryPgpKeys(signingKey, signingPassword)
-    } else {
-        isRequired = false
     }
     sign(extensions.getByType<PublishingExtension>().publications.getByName(publicationName))
 }


### PR DESCRIPTION
This change turns signing our artifacts back on, which I disabled for local publishing and accidentally left in PR. :shame: