### PR TITLE
New conditions to not apply SwitchLiteralFirstComparisonsCodemod

### DIFF
--- a/core-codemods/src/intTest/java/io/codemodder/integration/WebGoat822Test.java
+++ b/core-codemods/src/intTest/java/io/codemodder/integration/WebGoat822Test.java
@@ -95,7 +95,7 @@ final class WebGoat822Test extends GitRepositoryTest {
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
 
-    assertThat(fileChanges.size(), is(56));
+    assertThat(fileChanges.size(), is(50));
 
     // we only inject into a couple files
     verifyStandardCodemodResults(fileChanges);
@@ -133,7 +133,7 @@ final class WebGoat822Test extends GitRepositoryTest {
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
 
-    assertThat(fileChanges.size(), is(60));
+    assertThat(fileChanges.size(), is(54));
 
     verifyStandardCodemodResults(fileChanges);
 

--- a/core-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
@@ -64,9 +64,13 @@ public final class SwitchLiteralFirstComparisonsCodemod
     final Optional<SimpleName> simpleNameOptional = getSimpleNameFromMethodCallExpr(methodCallExpr);
 
     /**
-     * This codemod will not be executed if: 1. Variable was previously initialized to a not null
-     * value 2. Variable has a previous not null assertion 3. Variable has a {@code @NotNull} or
-     * {@code @Nonnull} annotation
+     * This codemod will not be executed if:
+     *
+     * <ol>
+     *   <li>Variable was previously initialized to a not null value
+     *   <li>Variable has a previous not null assertion
+     *   <li>Variable has a {@link @NotNull} or {@link @Nonnull} annotation
+     * </ol>
      */
     if (simpleNameOptional.isPresent()
         && (isSimpleNameANotNullInitializedVariableDeclarator(
@@ -93,8 +97,13 @@ public final class SwitchLiteralFirstComparisonsCodemod
   }
 
   /**
-   * Method used to check if variable (nameNode) has a previous node that represents: 1. A not null
-   * assertion 2. A not null annotation 3. An initialization to a not null value
+   * Method used to check if variable (nameNode) has a previous node that represents:
+   *
+   * <ol>
+   *   <li>A not null assertion
+   *   <li>A not null annotation
+   *   <li>An initialization to a not null value
+   * </ol>
    */
   private boolean isPreviousNodeBefore(final Node nameNode, final Node previousNode) {
     final Optional<Range> nameNodeRange = nameNode.getRange();
@@ -106,7 +115,7 @@ public final class SwitchLiteralFirstComparisonsCodemod
   }
 
   /**
-   * Checks if the given Variable {@code SimpleName} has a previous null assertion in the {@code
+   * Checks if the given Variable {@link SimpleName} has a previous null assertion in the {@link
    * CompilationUnit}.
    */
   private boolean hasSimpleNamePreviousNullAssertion(
@@ -132,9 +141,9 @@ public final class SwitchLiteralFirstComparisonsCodemod
   }
 
   /**
-   * Checks if the given {@code Node} is a binary expression child node and is equal to the provided
-   * {@code SimpleName}. Additionally, it verifies if the child node is located before the provided
-   * {@code SimpleName}.
+   * Checks if the given {@link Node} is a binary expression child node and is equal to the provided
+   * {@link SimpleName}. Additionally, it verifies if the child node is located before the provided
+   * {@link SimpleName}.
    */
   private boolean isBinaryNodeChildEqualToSimpleName(final Node child, final SimpleName name) {
     return child instanceof NameExpr nameExpr
@@ -143,8 +152,8 @@ public final class SwitchLiteralFirstComparisonsCodemod
   }
 
   /**
-   * Checks if the given {@code SimpleName} variable has a @NotNull or @Nonnull annotation in the
-   * provided {@code CompilationUnit}.
+   * Checks if the given {@link SimpleName} variable has a @NotNull or @Nonnull annotation in the
+   * provided {@link CompilationUnit}.
    */
   private boolean hasSimpleNameNotNullAnnotation(
       final CompilationUnit cu,
@@ -168,8 +177,8 @@ public final class SwitchLiteralFirstComparisonsCodemod
   }
 
   /**
-   * Checks if the given {@code Node} represents a @NotNull or @Nonnull annotation for a
-   * FieldDeclaration and the associated VariableDeclarator has the provided {@code SimpleName}.
+   * Checks if the given {@link Node} represents a @NotNull or @Nonnull annotation for a
+   * FieldDeclaration and the associated VariableDeclarator has the provided {@link SimpleName}.
    */
   private boolean isSimpleNotNullAnnotationForFieldDeclaration(
       final Node annotation, final SimpleName simpleName) {
@@ -185,8 +194,8 @@ public final class SwitchLiteralFirstComparisonsCodemod
   }
 
   /**
-   * Checks if the given {@code Node} represents a @NotNull or @Nonnull annotation for a Parameter
-   * or VariableDeclarator, and the associated SimpleName matches the provided {@code SimpleName}.
+   * Checks if the given {@link Node} represents a @NotNull or @Nonnull annotation for a Parameter
+   * or VariableDeclarator, and the associated SimpleName matches the provided {@link SimpleName}.
    */
   private boolean isSimpleNotNullAnnotationForParameterOrVariable(
       final Node annotation, final SimpleName simpleName) {
@@ -223,8 +232,8 @@ public final class SwitchLiteralFirstComparisonsCodemod
   }
 
   /**
-   * Checks if the provided {@code SimpleName} variable corresponds to a VariableDeclarator that was
-   * previously initialized to a non-null value.
+   * Checks if the provided {@link SimpleName} variable corresponds to a {@link VariableDeclarator}
+   * that was previously initialized to a non-null value.
    */
   private boolean isSimpleNameANotNullInitializedVariableDeclarator(
       final List<VariableDeclarator> variableDeclarators, final SimpleName targetName) {
@@ -244,8 +253,8 @@ public final class SwitchLiteralFirstComparisonsCodemod
   }
 
   /**
-   * Retrieves the SimpleName from the given MethodCallExpr. We know that this codemod only filters
-   * MethodCallExpr nodes that has one SimpleName node.
+   * Retrieves the {@link SimpleName} from the given {@link MethodCallExpr}. This codemod assumes
+   * that {@link MethodCallExpr} nodes contain only one {@link SimpleName} node.
    */
   private Optional<SimpleName> getSimpleNameFromMethodCallExpr(
       final MethodCallExpr methodCallExpr) {

--- a/core-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
@@ -73,12 +73,12 @@ public final class SwitchLiteralFirstComparisonsCodemod
     final List<FieldDeclaration> fieldDeclarations = cu.findAll(FieldDeclaration.class);
     final List<Parameter> parameters = cu.findAll(Parameter.class);
     // Create a new list to collect all annotation nodes
-    List<Node> annotationNodesCandidates = new ArrayList<>();
+    final List<Node> annotationNodesCandidates = new ArrayList<>();
     annotationNodesCandidates.addAll(variableDeclarators);
     annotationNodesCandidates.addAll(fieldDeclarations);
     annotationNodesCandidates.addAll(parameters);
 
-    List<Node> annotationNodes = filterNodesWithNotNullAnnotations(annotationNodesCandidates);
+    final List<Node> annotationNodes = filterNodesWithNotNullAnnotations(annotationNodesCandidates);
 
     if (hasSimpleNameNotNullAnnotation(annotationNodes, simpleName)) {
       return false;
@@ -93,20 +93,20 @@ public final class SwitchLiteralFirstComparisonsCodemod
     Expression leftSide = methodCallExpr.getScope().get();
     Expression rightSide = methodCallExpr.getArgument(0);
     try {
-      ResolvedType leftType = leftSide.calculateResolvedType();
+      final ResolvedType leftType = leftSide.calculateResolvedType();
       if ("Ljava/lang/String;".equals(leftType.toDescriptor())) {
         methodCallExpr.setScope(rightSide);
         methodCallExpr.setArgument(0, leftSide);
         return true;
       }
-    } catch (UnsolvedSymbolException e) {
+    } catch (final UnsolvedSymbolException e) {
       // expected in cases where we can't resolve the type
     }
 
     return false;
   }
 
-  public boolean isPreviousNodeBefore(Node nameNode, Node previousNode) {
+  private boolean isPreviousNodeBefore(final Node nameNode, final Node previousNode) {
     final Optional<Range> nameNodeRange = nameNode.getRange();
     final Optional<Range> previosNodeRange = previousNode.getRange();
     if (nameNodeRange.isEmpty() || previosNodeRange.isEmpty()) {
@@ -115,16 +115,16 @@ public final class SwitchLiteralFirstComparisonsCodemod
     return previosNodeRange.get().begin.isBefore(nameNodeRange.get().begin);
   }
 
-  public boolean hasSimpleNamePreviousNullAssertion(
-      List<NullLiteralExpr> nullLiterals, SimpleName name) {
+  private boolean hasSimpleNamePreviousNullAssertion(
+      final List<NullLiteralExpr> nullLiterals, final SimpleName name) {
 
     if (nullLiterals != null && !nullLiterals.isEmpty()) {
-      for (NullLiteralExpr nullLiteralExpr : nullLiterals) {
+      for (final NullLiteralExpr nullLiteralExpr : nullLiterals) {
         if (nullLiteralExpr.getParentNode().isPresent()
             && nullLiteralExpr.getParentNode().get() instanceof BinaryExpr parentBinaryExpr) {
           if (parentBinaryExpr.getOperator() == BinaryExpr.Operator.NOT_EQUALS) {
-            Node left = parentBinaryExpr.getLeft();
-            Node right = parentBinaryExpr.getRight();
+            final Node left = parentBinaryExpr.getLeft();
+            final Node right = parentBinaryExpr.getRight();
             if (isBinaryNodeChildEqualToSimpleName(left, name)
                 || isBinaryNodeChildEqualToSimpleName(right, name)) {
               return true;
@@ -143,21 +143,22 @@ public final class SwitchLiteralFirstComparisonsCodemod
         && isPreviousNodeBefore(name, nameExpr.getName());
   }
 
-  public boolean hasSimpleNameNotNullAnnotation(List<Node> annotations, SimpleName simpleName) {
+  private boolean hasSimpleNameNotNullAnnotation(
+      final List<Node> annotations, final SimpleName simpleName) {
 
     if (annotations != null && !annotations.isEmpty()) {
-      for (Node annotation : annotations) {
+      for (final Node annotation : annotations) {
 
         if (annotation instanceof Parameter || annotation instanceof VariableDeclarator) {
-          SimpleName annotationSimpleName = ((NodeWithSimpleName<?>) annotation).getName();
+          final SimpleName annotationSimpleName = ((NodeWithSimpleName<?>) annotation).getName();
           if (annotationSimpleName.equals(simpleName)
               && isPreviousNodeBefore(simpleName, annotationSimpleName)) {
             return true;
           }
         } else if (annotation instanceof FieldDeclaration fieldDeclaration) {
           final List<VariableDeclarator> variableDeclarators = fieldDeclaration.getVariables();
-          for (VariableDeclarator variableDeclarator : variableDeclarators) {
-            SimpleName variableSimpleName = variableDeclarator.getName();
+          for (final VariableDeclarator variableDeclarator : variableDeclarators) {
+            final SimpleName variableSimpleName = variableDeclarator.getName();
             if (variableSimpleName.equals(simpleName)
                 && isPreviousNodeBefore(simpleName, variableSimpleName)) {
               return true;
@@ -170,9 +171,9 @@ public final class SwitchLiteralFirstComparisonsCodemod
     return false;
   }
 
-  public List<Node> filterNodesWithNotNullAnnotations(List<Node> annotationNodes) {
-    List<Node> nodesWithNotNullAnnotations = new ArrayList<>();
-    for (Node node : annotationNodes) {
+  private List<Node> filterNodesWithNotNullAnnotations(final List<Node> annotationNodes) {
+    final List<Node> nodesWithNotNullAnnotations = new ArrayList<>();
+    for (final Node node : annotationNodes) {
       if (node instanceof NodeWithAnnotations<?> nodeWithAnnotations
           && !nodeWithAnnotations.getAnnotations().isEmpty()
           && hasNotNullOrNonnullAnnotation(nodeWithAnnotations.getAnnotations())) {
@@ -182,8 +183,8 @@ public final class SwitchLiteralFirstComparisonsCodemod
     return nodesWithNotNullAnnotations;
   }
 
-  public boolean hasNotNullOrNonnullAnnotation(NodeList<AnnotationExpr> annotations) {
-    for (AnnotationExpr annotation : annotations) {
+  private boolean hasNotNullOrNonnullAnnotation(final NodeList<AnnotationExpr> annotations) {
+    for (final AnnotationExpr annotation : annotations) {
       if (isNotNullOrNonnullAnnotation(annotation)) {
         return true;
       }
@@ -191,19 +192,19 @@ public final class SwitchLiteralFirstComparisonsCodemod
     return false;
   }
 
-  private boolean isNotNullOrNonnullAnnotation(AnnotationExpr annotation) {
+  private boolean isNotNullOrNonnullAnnotation(final AnnotationExpr annotation) {
 
-    Name annotationName = annotation.getName();
-    String name = annotationName.getIdentifier();
+    final Name annotationName = annotation.getName();
+    final String name = annotationName.getIdentifier();
     return "NotNull".equals(name) || "Nonnull".equals(name);
   }
 
-  public boolean isSimpleNameANotNullInitializedVariableDeclarator(
-      List<VariableDeclarator> variableDeclarators, SimpleName targetName) {
+  private final boolean isSimpleNameANotNullInitializedVariableDeclarator(
+      final List<VariableDeclarator> variableDeclarators, final SimpleName targetName) {
 
     if (targetName != null) {
-      for (VariableDeclarator declarator : variableDeclarators) {
-        SimpleName declaratorSimpleName = declarator.getName();
+      for (final VariableDeclarator declarator : variableDeclarators) {
+        final SimpleName declaratorSimpleName = declarator.getName();
         if (declaratorSimpleName.equals(targetName)
             && isPreviousNodeBefore(targetName, declaratorSimpleName)) {
           final Optional<Expression> initializer = declarator.getInitializer();
@@ -215,14 +216,14 @@ public final class SwitchLiteralFirstComparisonsCodemod
     return false;
   }
 
-  public List<SimpleName> getSimpleNames(MethodCallExpr methodCallExpr) {
-    List<SimpleName> nameExprNodes = new ArrayList<>();
+  private List<SimpleName> getSimpleNames(final MethodCallExpr methodCallExpr) {
+    final List<SimpleName> nameExprNodes = new ArrayList<>();
 
     // Get the arguments of the MethodCallExpr
-    List<Node> childNodes = methodCallExpr.getChildNodes();
+    final List<Node> childNodes = methodCallExpr.getChildNodes();
 
     // Iterate through the arguments and collect NameExpr nodes
-    for (Node node : childNodes) {
+    for (final Node node : childNodes) {
       if (node instanceof NameExpr nameExpr) {
         nameExprNodes.add(nameExpr.getName());
       }

--- a/core-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
@@ -106,7 +106,7 @@ public final class SwitchLiteralFirstComparisonsCodemod
     return false;
   }
 
-  public static boolean isPreviousNodeBefore(Node nameNode, Node previousNode) {
+  public boolean isPreviousNodeBefore(Node nameNode, Node previousNode) {
     final Optional<Range> nameNodeRange = nameNode.getRange();
     final Optional<Range> previosNodeRange = previousNode.getRange();
     if (nameNodeRange.isEmpty() || previosNodeRange.isEmpty()) {
@@ -125,13 +125,8 @@ public final class SwitchLiteralFirstComparisonsCodemod
           if (parentBinaryExpr.getOperator() == BinaryExpr.Operator.NOT_EQUALS) {
             Node left = parentBinaryExpr.getLeft();
             Node right = parentBinaryExpr.getRight();
-            if (left instanceof NameExpr nameExpr
-                && nameExpr.getName().equals(name)
-                && isPreviousNodeBefore(name, nameExpr.getName())) {
-              return true;
-            } else if (right instanceof NameExpr nameExpr
-                && nameExpr.getName().equals(name)
-                && isPreviousNodeBefore(name, nameExpr.getName())) {
+            if (isBinaryNodeChildEqualToSimpleName(left, name)
+                || isBinaryNodeChildEqualToSimpleName(right, name)) {
               return true;
             }
           }
@@ -142,8 +137,13 @@ public final class SwitchLiteralFirstComparisonsCodemod
     return false;
   }
 
-  public static boolean hasSimpleNameNotNullAnnotation(
-      List<Node> annotations, SimpleName simpleName) {
+  private boolean isBinaryNodeChildEqualToSimpleName(final Node child, final SimpleName name) {
+    return child instanceof NameExpr nameExpr
+        && nameExpr.getName().equals(name)
+        && isPreviousNodeBefore(name, nameExpr.getName());
+  }
+
+  public boolean hasSimpleNameNotNullAnnotation(List<Node> annotations, SimpleName simpleName) {
 
     if (annotations != null && !annotations.isEmpty()) {
       for (Node annotation : annotations) {
@@ -170,7 +170,7 @@ public final class SwitchLiteralFirstComparisonsCodemod
     return false;
   }
 
-  public static List<Node> filterNodesWithNotNullAnnotations(List<Node> annotationNodes) {
+  public List<Node> filterNodesWithNotNullAnnotations(List<Node> annotationNodes) {
     List<Node> nodesWithNotNullAnnotations = new ArrayList<>();
     for (Node node : annotationNodes) {
       if (node instanceof NodeWithAnnotations<?> nodeWithAnnotations
@@ -182,7 +182,7 @@ public final class SwitchLiteralFirstComparisonsCodemod
     return nodesWithNotNullAnnotations;
   }
 
-  public static boolean hasNotNullOrNonnullAnnotation(NodeList<AnnotationExpr> annotations) {
+  public boolean hasNotNullOrNonnullAnnotation(NodeList<AnnotationExpr> annotations) {
     for (AnnotationExpr annotation : annotations) {
       if (isNotNullOrNonnullAnnotation(annotation)) {
         return true;
@@ -191,14 +191,14 @@ public final class SwitchLiteralFirstComparisonsCodemod
     return false;
   }
 
-  private static boolean isNotNullOrNonnullAnnotation(AnnotationExpr annotation) {
+  private boolean isNotNullOrNonnullAnnotation(AnnotationExpr annotation) {
 
     Name annotationName = annotation.getName();
     String name = annotationName.getIdentifier();
     return "NotNull".equals(name) || "Nonnull".equals(name);
   }
 
-  public static boolean isSimpleNameANotNullInitializedVariableDeclarator(
+  public boolean isSimpleNameANotNullInitializedVariableDeclarator(
       List<VariableDeclarator> variableDeclarators, SimpleName targetName) {
 
     if (targetName != null) {
@@ -215,7 +215,7 @@ public final class SwitchLiteralFirstComparisonsCodemod
     return false;
   }
 
-  public static List<SimpleName> getSimpleNames(MethodCallExpr methodCallExpr) {
+  public List<SimpleName> getSimpleNames(MethodCallExpr methodCallExpr) {
     List<SimpleName> nameExprNodes = new ArrayList<>();
 
     // Get the arguments of the MethodCallExpr
@@ -223,8 +223,7 @@ public final class SwitchLiteralFirstComparisonsCodemod
 
     // Iterate through the arguments and collect NameExpr nodes
     for (Node node : childNodes) {
-      if (node instanceof NameExpr) {
-        final NameExpr nameExpr = (NameExpr) node;
+      if (node instanceof NameExpr nameExpr) {
         nameExprNodes.add(nameExpr.getName());
       }
     }

--- a/core-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
@@ -244,14 +244,14 @@ public final class SwitchLiteralFirstComparisonsCodemod
 
     return targetName != null
         && variableDeclarators.stream()
+            .filter(declarator -> declarator.getName().equals(targetName))
+            .filter(declarator -> isPreviousNodeBefore(targetName, declarator.getName()))
             .anyMatch(
                 declarator ->
-                    declarator.getName().equals(targetName)
-                        && isPreviousNodeBefore(targetName, declarator.getName())
-                        && declarator
-                            .getInitializer()
-                            .map(expr -> !(expr instanceof NullLiteralExpr))
-                            .orElse(false));
+                    declarator
+                        .getInitializer()
+                        .map(expr -> !(expr instanceof NullLiteralExpr))
+                        .orElse(false));
   }
 
   /**

--- a/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.after
+++ b/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.after
@@ -30,6 +30,12 @@ final class Test {
        if(obj.equals("foo")) { // can't change because the semantics are different
          System.out.println("foo");
        }
+
+       if(outerNullAssertion != null) {
+          if(outerNullAssertion.equals("something")) { // shouldn't be changed because already checked in outer block
+            System.out.println("outer");
+          }
+       }
    }
 
    private String getBar() { return null; }

--- a/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.after
+++ b/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.after
@@ -7,14 +7,19 @@ final class Test {
     static boolean cantChange = bar.equals("foo"); // can't change because we don't know the type of bar
     final boolean change2 = "foo".equalsIgnoreCase(getBar());
 
-   void foo(String foo) {
+   void foo(String foo, @NotNull String foo1) {
        boolean change1 = "bar".equals(foo);
+       String initializedVar = "init";
        if("bar".equals(foo)) { // should change
            System.out.println("foo");
        } else if(foo.compareTo("bar") > 0) { // shouldn't change, can't mess with compareTo
            System.out.println("foo");
        } else if("foo".equals(bar)) { // should be fine
            System.out.println("foo");
+       } else if(foo1.equals("bar")) { // shouldn't change because foo1 is @NotNull
+           System.out.println("foo");
+       } else if(initializedVar.equals("init")) { // shouldn't change because initializedVar is initialized
+           System.out.println("init");
        }
 
        Object obj = new Object();

--- a/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.after
+++ b/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.after
@@ -7,7 +7,7 @@ final class Test {
     static boolean cantChange = bar.equals("foo"); // can't change because we don't know the type of bar
     final boolean change2 = "foo".equalsIgnoreCase(getBar());
 
-   void foo(String foo, @NotNull String foo1) {
+   void foo(String foo, @NotNull String foo1, String nullAssertion) {
        boolean change1 = "bar".equals(foo);
        String initializedVar = "init";
        if("bar".equals(foo)) { // should change
@@ -20,6 +20,10 @@ final class Test {
            System.out.println("foo");
        } else if(initializedVar.equals("init")) { // shouldn't change because initializedVar is initialized
            System.out.println("init");
+       }
+
+       if(nullAssertion != null && nullAssertion.equals("anything")){ // shouldn't change because previous null assertion
+           System.out.println("null");
        }
 
        Object obj = new Object();

--- a/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.before
+++ b/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.before
@@ -7,14 +7,19 @@ final class Test {
     static boolean cantChange = bar.equals("foo"); // can't change because we don't know the type of bar
     final boolean change2 = getBar().equalsIgnoreCase("foo");
 
-   void foo(String foo) {
+   void foo(String foo, @NotNull String foo1) {
        boolean change1 = foo.equals("bar");
+       String initializedVar = "init";
        if(foo.equals("bar")) { // should change
            System.out.println("foo");
        } else if(foo.compareTo("bar") > 0) { // shouldn't change, can't mess with compareTo
            System.out.println("foo");
        } else if("foo".equals(bar)) { // should be fine
            System.out.println("foo");
+       } else if(foo1.equals("bar")) { // shouldn't change because foo1 is @NotNull
+           System.out.println("foo");
+       } else if(initializedVar.equals("init")) { // shouldn't change because initializedVar is initialized
+           System.out.println("init");
        }
 
        Object obj = new Object();

--- a/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.before
+++ b/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.before
@@ -30,6 +30,12 @@ final class Test {
        if(obj.equals("foo")) { // can't change because the semantics are different
          System.out.println("foo");
        }
+
+       if(outerNullAssertion != null) {
+          if(outerNullAssertion.equals("something")) { // shouldn't be changed because already checked in outer block
+            System.out.println("outer");
+          }
+       }
    }
 
    private String getBar() { return null; }

--- a/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.before
+++ b/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.before
@@ -7,7 +7,7 @@ final class Test {
     static boolean cantChange = bar.equals("foo"); // can't change because we don't know the type of bar
     final boolean change2 = getBar().equalsIgnoreCase("foo");
 
-   void foo(String foo, @NotNull String foo1) {
+   void foo(String foo, @NotNull String foo1, String nullAssertion) {
        boolean change1 = foo.equals("bar");
        String initializedVar = "init";
        if(foo.equals("bar")) { // should change
@@ -20,6 +20,10 @@ final class Test {
            System.out.println("foo");
        } else if(initializedVar.equals("init")) { // shouldn't change because initializedVar is initialized
            System.out.println("init");
+       }
+
+       if(nullAssertion != null && nullAssertion.equals("anything")){ // shouldn't change because previous null assertion
+           System.out.println("null");
        }
 
        Object obj = new Object();


### PR DESCRIPTION
This codemod will not be executed if: 
1. Variable was previously initialized to a not null value 
2. Variable has a previous not null assertion 
3. Variable has a `@NotNull` / `@Nonnull `annotation

Related issue https://github.com/pixee/codemodder-java/issues/298