### PR TITLE
SwitchLiteralFirstComparisonsCodemod - check that variable initializer is a string

### DIFF
--- a/core-codemods/src/intTest/java/io/codemodder/integration/WebGoat822Test.java
+++ b/core-codemods/src/intTest/java/io/codemodder/integration/WebGoat822Test.java
@@ -95,7 +95,7 @@ final class WebGoat822Test extends GitRepositoryTest {
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
 
-    assertThat(fileChanges.size(), is(50));
+    assertThat(fileChanges.size(), is(54));
 
     // we only inject into a couple files
     verifyStandardCodemodResults(fileChanges);
@@ -133,7 +133,7 @@ final class WebGoat822Test extends GitRepositoryTest {
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
 
-    assertThat(fileChanges.size(), is(54));
+    assertThat(fileChanges.size(), is(58));
 
     verifyStandardCodemodResults(fileChanges);
 

--- a/core-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SwitchLiteralFirstComparisonsCodemod.java
@@ -16,6 +16,7 @@ import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
@@ -250,8 +251,8 @@ public final class SwitchLiteralFirstComparisonsCodemod
                 declarator ->
                     declarator
                         .getInitializer()
-                        .map(expr -> !(expr instanceof NullLiteralExpr))
-                        .orElse(false));
+                        .filter(StringLiteralExpr.class::isInstance)
+                        .isPresent());
   }
 
   /**

--- a/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.after
+++ b/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.after
@@ -10,6 +10,8 @@ final class Test {
    void foo(String foo, @NotNull String foo1, String nullAssertion) {
        boolean change1 = "bar".equals(foo);
        String initializedVar = "init";
+       String notSureItIsInitialized = someMethod();
+       String notSureItIsInitialized2 = randomVar;
        if("bar".equals(foo)) { // should change
            System.out.println("foo");
        } else if(foo.compareTo("bar") > 0) { // shouldn't change, can't mess with compareTo
@@ -35,6 +37,14 @@ final class Test {
           if(outerNullAssertion.equals("something")) { // shouldn't be changed because already checked in outer block
             System.out.println("outer");
           }
+       }
+
+       if("1".equals(notSureItIsInitialized)){ // shouldn't be changed because we can't assume method returns a not null value
+          System.out.println("One");
+       }
+
+       if("2".equals(notSureItIsInitialized2)){ // shouldn't be changed because we can't assume variable is a not null value
+          System.out.println("Two");
        }
    }
 

--- a/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.before
+++ b/core-codemods/src/test/resources/switch-literal-first-comparisons/Test.java.before
@@ -10,6 +10,8 @@ final class Test {
    void foo(String foo, @NotNull String foo1, String nullAssertion) {
        boolean change1 = foo.equals("bar");
        String initializedVar = "init";
+       String notSureItIsInitialized = someMethod();
+       String notSureItIsInitialized2 = randomVar;
        if(foo.equals("bar")) { // should change
            System.out.println("foo");
        } else if(foo.compareTo("bar") > 0) { // shouldn't change, can't mess with compareTo
@@ -35,6 +37,14 @@ final class Test {
           if(outerNullAssertion.equals("something")) { // shouldn't be changed because already checked in outer block
             System.out.println("outer");
           }
+       }
+
+       if(notSureItIsInitialized.equals("1")){ // shouldn't be changed because we can't assume method returns a not null value
+          System.out.println("One");
+       }
+
+       if(notSureItIsInitialized2.equals("2")){ // shouldn't be changed because we can't assume variable is a not null value
+          System.out.println("Two");
        }
    }
 


### PR DESCRIPTION
In order to avoid assuming that given initializer for the string variable is a not null value, we check that initializer is a StringLiteralExpr