### PR TITLE
Add detection tool metadata to CodeTF

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/AddMissingOverrideCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/AddMissingOverrideCodemod.java
@@ -5,6 +5,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.SimpleName;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -24,6 +25,14 @@ public final class AddMissingOverrideCodemod extends SonarPluginJavaParserChange
   public AddMissingOverrideCodemod(
       @ProvidedSonarScan(ruleId = "java:S1161") final RuleIssues issues) {
     super(issues, SimpleName.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S1161",
+        "`@Override` should be used on overriding and implementing methods",
+        "https://rules.sonarsource.com/java/RSPEC-1161/");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/AvoidImplicitPublicConstructorCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/AvoidImplicitPublicConstructorCodemod.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.expr.SimpleName;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -29,6 +30,13 @@ public final class AvoidImplicitPublicConstructorCodemod
   public AvoidImplicitPublicConstructorCodemod(
       @ProvidedSonarScan(ruleId = "java:S1118") final RuleIssues issues) {
     super(issues, SimpleName.class);
+  }
+
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S1118",
+        "Utility classes should not have public constructors",
+        "https://rules.sonarsource.com/java/RSPEC-1118/");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/DeclareVariableOnSeparateLineCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/DeclareVariableOnSeparateLineCodemod.java
@@ -7,6 +7,7 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithVariables;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -26,6 +27,14 @@ public final class DeclareVariableOnSeparateLineCodemod
   public DeclareVariableOnSeparateLineCodemod(
       @ProvidedSonarScan(ruleId = "java:S1659") final RuleIssues issues) {
     super(issues, VariableDeclarator.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S1659",
+        "Multiple variables should not be declared on the same line",
+        "https://rules.sonarsource.com/java/RSPEC-1659/");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/DefineConstantForLiteralCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/DefineConstantForLiteralCodemod.java
@@ -3,6 +3,7 @@ package io.codemodder.codemods;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -22,6 +23,14 @@ public final class DefineConstantForLiteralCodemod
   public DefineConstantForLiteralCodemod(
       @ProvidedSonarScan(ruleId = "java:S1192") final RuleIssues issues) {
     super(issues, StringLiteralExpr.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S1192",
+        "String literals should not be duplicated",
+        "https://rules.sonarsource.com/java/RSPEC-1192/");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/FixRedundantStaticOnEnumCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/FixRedundantStaticOnEnumCodemod.java
@@ -3,6 +3,7 @@ package io.codemodder.codemods;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -22,6 +23,14 @@ public final class FixRedundantStaticOnEnumCodemod
   public FixRedundantStaticOnEnumCodemod(
       @ProvidedSonarScan(ruleId = "java:S2786") final RuleIssues issues) {
     super(issues, EnumDeclaration.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S2786",
+        "Nested `enum`s should not be declared static",
+        "https://rules.sonarsource.com/java/RSPEC-2786/");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/HardenStringParseToPrimitivesCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/HardenStringParseToPrimitivesCodemod.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.type.Type;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -61,6 +62,14 @@ public final class HardenStringParseToPrimitivesCodemod extends CompositeJavaPar
     }
 
     @Override
+    protected DetectorRule getDetectorRule() {
+      return new DetectorRule(
+          "java:S2130",
+          "Parsing should be used to convert `String`s to primitives",
+          "https://rules.sonarsource.com/java/RSPEC-2130/");
+    }
+
+    @Override
     public boolean onIssueFound(
         final CodemodInvocationContext context,
         final CompilationUnit cu,
@@ -112,6 +121,14 @@ public final class HardenStringParseToPrimitivesCodemod extends CompositeJavaPar
           MethodCallExpr.class,
           RegionNodeMatcher.MATCHES_START,
           CodemodReporterStrategy.empty());
+    }
+
+    @Override
+    protected DetectorRule getDetectorRule() {
+      return new DetectorRule(
+          "java:S2130",
+          "Parsing should be used to convert `String`s to primitives",
+          "https://rules.sonarsource.com/java/RSPEC-2130/");
     }
 
     @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/OverridesMatchParentSynchronizationCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/OverridesMatchParentSynchronizationCodemod.java
@@ -5,6 +5,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.SimpleName;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -28,6 +29,14 @@ public final class OverridesMatchParentSynchronizationCodemod
   public OverridesMatchParentSynchronizationCodemod(
       @ProvidedSonarScan(ruleId = "java:S3551") final RuleIssues issues) {
     super(issues, SimpleName.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S3551",
+        "Overrides should match their parent class methods in synchronization",
+        "https://rules.sonarsource.com/java/RSPEC-3551");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveCommentedCodeCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveCommentedCodeCodemod.java
@@ -3,6 +3,7 @@ package io.codemodder.codemods;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.comments.Comment;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -32,6 +33,14 @@ public final class RemoveCommentedCodeCodemod extends SonarPluginJavaParserChang
       @ProvidedSonarScan(ruleId = "java:S125") final RuleIssues issues) {
 
     super(issues, Comment.class, regionNodeMatcher, NodeCollector.ALL_COMMENTS);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S125",
+        "Sections of code should not be commented out",
+        "https://rules.sonarsource.com/java/RSPEC-125");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveRedundantVariableCreationCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveRedundantVariableCreationCodemod.java
@@ -4,6 +4,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.*;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -24,6 +25,14 @@ public final class RemoveRedundantVariableCreationCodemod
   public RemoveRedundantVariableCreationCodemod(
       @ProvidedSonarScan(ruleId = "java:S1488") final RuleIssues issues) {
     super(issues, ObjectCreationExpr.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S1488",
+        "Local variables should not be declared and then immediately returned or thrown",
+        "https://rules.sonarsource.com/java/RSPEC-1488");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.*;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -34,6 +35,14 @@ public final class RemoveUnusedLocalVariableCodemod
   public RemoveUnusedLocalVariableCodemod(
       @ProvidedSonarScan(ruleId = "java:S1481") final RuleIssues issues) {
     super(issues, VariableDeclarator.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S1481",
+        "Unused local variables should be removed",
+        "https://rules.sonarsource.com/java/RSPEC-1481");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedPrivateMethodCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveUnusedPrivateMethodCodemod.java
@@ -5,6 +5,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.SimpleName;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -25,6 +26,14 @@ public final class RemoveUnusedPrivateMethodCodemod
   public RemoveUnusedPrivateMethodCodemod(
       @ProvidedSonarScan(ruleId = "java:S1144") final RuleIssues issues) {
     super(issues, SimpleName.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S1144",
+        "Unused private methods should be removed",
+        "https://rules.sonarsource.com/java/RSPEC-1144");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveUselessParenthesesCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveUselessParenthesesCodemod.java
@@ -4,6 +4,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.Expression;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -23,6 +24,14 @@ public final class RemoveUselessParenthesesCodemod
   public RemoveUselessParenthesesCodemod(
       @ProvidedSonarScan(ruleId = "java:S1110") final RuleIssues issues) {
     super(issues, EnclosedExpr.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S1110",
+        "Redundant pairs of parentheses should be removed",
+        "https://rules.sonarsource.com/java/RSPEC-1110");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod.java
@@ -5,6 +5,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -25,6 +26,14 @@ public final class ReplaceStreamCollectorsToListCodemod
   public ReplaceStreamCollectorsToListCodemod(
       @ProvidedSonarScan(ruleId = "java:S6204") final RuleIssues issues) {
     super(issues, MethodCallExpr.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S6204",
+        "`Stream.toList()` should be used instead of `collectors`",
+        "https://rules.sonarsource.com/java/RSPEC-6204");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/SimplifyRestControllerAnnotationsCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SimplifyRestControllerAnnotationsCodemod.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -32,6 +33,14 @@ public final class SimplifyRestControllerAnnotationsCodemod
   public SimplifyRestControllerAnnotationsCodemod(
       @ProvidedSonarScan(ruleId = "java:S6833") final RuleIssues issues) {
     super(issues, ClassOrInterfaceDeclaration.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S6833",
+        "`@Controller` should be replaced with `@RestController`",
+        "https://rules.sonarsource.com/java/RSPEC-6833");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/SubstituteReplaceAllCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SubstituteReplaceAllCodemod.java
@@ -3,6 +3,7 @@ package io.codemodder.codemods;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.SimpleName;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.providers.sonar.ProvidedSonarScan;
 import io.codemodder.providers.sonar.RuleIssues;
 import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
@@ -21,6 +22,14 @@ public final class SubstituteReplaceAllCodemod extends SonarPluginJavaParserChan
   public SubstituteReplaceAllCodemod(
       @ProvidedSonarScan(ruleId = "java:S5361") final RuleIssues issues) {
     super(issues, SimpleName.class);
+  }
+
+  @Override
+  protected DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "java:S5361",
+        "`String#replace` should be preferred to `String#replaceAll`",
+        "https://rules.sonarsource.com/java/RSPEC-5361");
   }
 
   @Override

--- a/core-codemods/src/main/resources/io/codemodder/codemods/AddMissingOverrideCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/AddMissingOverrideCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Added missing @Override parameter (Sonar)",
+  "summary" : "Added missing @Override parameter",
   "change" : "Added missing @Override parameter",
   "reviewGuidanceIJustification" : "There is no functional difference after the change, but the source code will be easier to understand.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/AvoidImplicitPublicConstructorCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/AvoidImplicitPublicConstructorCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Set private constructor to hide implicit public constructor (Sonar)",
+  "summary" : "Set private constructor to hide implicit public constructor",
   "change" : "Set private constructor to hide implicit public constructor",
   "reviewGuidanceIJustification" : "This change depends completely on Sonar's accuracy about in identifying types that are meant to only offer static utilities. Our testing shows this generally works as expected, but correctness can't be guaranteed in all situations.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/DeclareVariableOnSeparateLineCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/DeclareVariableOnSeparateLineCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Split variable declarations into their own statements (Sonar)",
+  "summary" : "Split variable declarations into their own statements ",
   "change" : "Split variable declarations into their own statements.",
   "reviewGuidanceIJustification" : "There is no functional difference after the change, but the source code will be easier to understand.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/DefineConstantForLiteralCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/DefineConstantForLiteralCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Define a constant for a literal string that is duplicated n times (Sonar)",
+  "summary" : "Define a constant for a literal string that is duplicated n times",
   "change" : "Define a constant for a literal string that is duplicated n times",
   "reviewGuidanceIJustification" : "This modification is intended to introduce no functional alterations. Nevertheless, we believe it would be beneficial for a developer to review the newly defined constant names to ensure they align with their expectations.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/FixRedundantStaticOnEnumCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/FixRedundantStaticOnEnumCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Removed redundant static flag on enum (Sonar)",
+  "summary" : "Removed redundant static flag on enum",
   "change" : "Removed redundant static flag on enum",
   "reviewGuidanceIJustification" : "There are no functional changes after this change, but the code will be easier to understand.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/HardenStringParseToPrimitivesCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/HardenStringParseToPrimitivesCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Implemented parsing usage when converting Strings to primitives (Sonar)",
+  "summary" : "Implemented parsing usage when converting Strings to primitives",
   "change" : "Implemented parsing usage when converting Strings to primitives.",
   "reviewGuidanceIJustification" : "There is no functional difference after the change, but the source code will be easier to understand.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/OverridesMatchParentSynchronizationCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/OverridesMatchParentSynchronizationCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Added missing synchronized keyword (Sonar)",
+  "summary" : "Added missing synchronized keyword",
   "change" : "Added missing synchronized keyword",
   "faqs" : [ {
       "question" : "Are there other ways to implement this?",

--- a/core-codemods/src/main/resources/io/codemodder/codemods/RemoveCommentedCodeCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/RemoveCommentedCodeCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Removed block of commented-out lines of code (Sonar)",
+  "summary" : "Removed block of commented-out lines of code",
   "change" : "Removed block of commented-out lines of code",
   "reviewGuidanceJustification" : "There is no functional difference after the change, but the source code will be easier to understand.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/RemoveRedundantVariableCreationCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/RemoveRedundantVariableCreationCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Remove redundant variable creation expression when it is only returned/thrown (Sonar)",
+  "summary" : "Remove redundant variable creation expression when it is only returned/thrown",
   "change" : "Remove redundant variable creation expression when it is only returned/thrown.",
   "reviewGuidanceJustification" : "There are no functional changes after this change, but the code will be easier to understand.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedLocalVariableCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Removed unused local variable (Sonar)",
+  "summary" : "Removed unused local variable",
   "change" : "Removed unused local variable",
   "reviewGuidanceJustification" : "There are no functional changes after this change, but the code will be easier to understand.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedPrivateMethodCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUnusedPrivateMethodCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Removed unused private method (Sonar)",
+  "summary" : "Removed unused private method",
   "change" : "Removed unused private method.",
   "reviewGuidanceJustification" : "There should be no functional changes after this change. However, we think it may be valuable for a developer to see the change being made and see if it alters their understanding of the code.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUselessParenthesesCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/RemoveUselessParenthesesCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Remove useless parentheses (Sonar)",
+  "summary" : "Remove useless parentheses",
   "change" : "Remove useless parentheses",
   "reviewGuidanceJustification" : "There should be no functional changes after this change, but the code should be easier to read.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/ReplaceStreamCollectorsToListCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Replaced `Stream.collect(Collectors.toList())` with `Stream.toList()` (Sonar)",
+  "summary" : "Replaced `Stream.collect(Collectors.toList())` with `Stream.toList()`",
   "change" : "Replaced `Stream.collect(Collectors.toList())` with `Stream.toList()`.",
   "reviewGuidanceJustification" : "There should be no functional changes after this change, but the code should be easier to read.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/SimplifyRestControllerAnnotationsCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/SimplifyRestControllerAnnotationsCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Replace `@Controller` with `@RestController` and remove `@ResponseBody` annotations (Sonar)",
+  "summary" : "Replace `@Controller` with `@RestController` and remove `@ResponseBody` annotations",
   "change" : "Replace `@Controller` with `@RestController` and remove `@ResponseBody` annotations.",
   "reviewGuidanceJustification" : "Although the readability and clarity has been increased, there is no functional difference between the code before, and code after.",
   "references" : [

--- a/core-codemods/src/main/resources/io/codemodder/codemods/SubstituteReplaceAllCodemod/report.json
+++ b/core-codemods/src/main/resources/io/codemodder/codemods/SubstituteReplaceAllCodemod/report.json
@@ -1,5 +1,5 @@
 {
-  "summary" : "Fixed inefficient usage of `String#replaceAll()` (Sonar)",
+  "summary" : "Fixed inefficient usage of `String#replaceAll()`",
   "change" : "Fixed inefficient usage of `String#replaceAll()`.",
   "reviewGuidanceJustification" : "There should be no functional changes after this change, but this depends on Sonar's accuracy Sonar in assessing whether the first argument contains regex metacharacters. Our testing shows this is a safe assumption, but the behavior can't be guaranteed.",
   "references" : [

--- a/framework/codemodder-base/build.gradle.kts
+++ b/framework/codemodder-base/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     api(libs.java.security.toolkit)
     api(libs.commons.lang3)
 
-    api("io.codemodder:codetf-java:3.0.1")
+    api("io.codemodder:codetf-java:3.2.0")
     api(libs.slf4j.api)
     api(libs.javaparser.core)
     api(libs.javaparser.symbolsolver.core)

--- a/framework/codemodder-base/src/main/java/io/codemodder/CodeChanger.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodeChanger.java
@@ -2,7 +2,6 @@ package io.codemodder;
 
 import io.codemodder.codetf.CodeTFReference;
 import io.codemodder.codetf.DetectionTool;
-
 import java.nio.file.Path;
 import java.util.List;
 

--- a/framework/codemodder-base/src/main/java/io/codemodder/CodeChanger.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodeChanger.java
@@ -1,6 +1,8 @@
 package io.codemodder;
 
 import io.codemodder.codetf.CodeTFReference;
+import io.codemodder.codetf.DetectionTool;
+
 import java.nio.file.Path;
 import java.util.List;
 
@@ -12,6 +14,11 @@ public interface CodeChanger {
 
   /** A deep description of what this codemod's changes. */
   String getDescription();
+
+  /** Detection tool metadata for this codemod. */
+  default DetectionTool getDetectionTool() {
+    return null;
+  }
 
   /**
    * A list of references for further reading on the issues this codemod addresses or other

--- a/framework/codemodder-base/src/main/java/io/codemodder/CodeChanger.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CodeChanger.java
@@ -1,7 +1,6 @@
 package io.codemodder;
 
 import io.codemodder.codetf.CodeTFReference;
-import io.codemodder.codetf.DetectionTool;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -13,11 +12,6 @@ public interface CodeChanger {
 
   /** A deep description of what this codemod's changes. */
   String getDescription();
-
-  /** Detection tool metadata for this codemod. */
-  default DetectionTool getDetectionTool() {
-    return null;
-  }
 
   /**
    * A list of references for further reading on the issues this codemod addresses or other

--- a/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
@@ -179,6 +179,7 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
             codemod.getId(),
             codeChanger.getSummary(),
             codeChanger.getDescription(),
+            codeChanger.getDetectionTool(),
             unscannableFiles.stream()
                 .map(file -> getRelativePath(projectDir, file))
                 .collect(Collectors.toSet()),

--- a/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
@@ -179,7 +179,9 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
             codemod.getId(),
             codeChanger.getSummary(),
             codeChanger.getDescription(),
-            codeChanger.getDetectionTool(),
+            codeChanger instanceof FixOnlyCodeChanger fixOnlyCodeChanger
+                ? fixOnlyCodeChanger.getDetectionTool()
+                : null,
             unscannableFiles.stream()
                 .map(file -> getRelativePath(projectDir, file))
                 .collect(Collectors.toSet()),

--- a/framework/codemodder-base/src/main/java/io/codemodder/FixOnlyCodeChanger.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/FixOnlyCodeChanger.java
@@ -1,0 +1,15 @@
+package io.codemodder;
+
+import io.codemodder.codetf.DetectionTool;
+
+/**
+ * A codemod that only fixes issues and does not perform its own detection, instead relying on
+ * external analysis from other tools
+ *
+ * <p>This is often provided via SARIF but can be provided by other means.
+ */
+public interface FixOnlyCodeChanger {
+
+  /** Detection tool metadata for this codemod. */
+  DetectionTool getDetectionTool();
+}

--- a/plugins/codemodder-plugin-sonar/src/main/java/io/codemodder/providers/sonar/SonarPluginJavaParserChanger.java
+++ b/plugins/codemodder-plugin-sonar/src/main/java/io/codemodder/providers/sonar/SonarPluginJavaParserChanger.java
@@ -4,6 +4,8 @@ import com.github.javaparser.Range;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectionTool;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.JavaParserChanger;
 import io.codemodder.providers.sonar.api.Issue;
 import java.util.ArrayList;
@@ -91,6 +93,13 @@ public abstract class SonarPluginJavaParserChanger<T extends Node> extends JavaP
   @Override
   public boolean shouldRun() {
     return ruleIssues.hasResults();
+  }
+
+  protected abstract DetectorRule getDetectorRule();
+
+  @Override
+  public DetectionTool getDetectionTool() {
+    return new DetectionTool("Sonar", getDetectorRule(), List.of());
   }
 
   /**

--- a/plugins/codemodder-plugin-sonar/src/main/java/io/codemodder/providers/sonar/SonarPluginJavaParserChanger.java
+++ b/plugins/codemodder-plugin-sonar/src/main/java/io/codemodder/providers/sonar/SonarPluginJavaParserChanger.java
@@ -13,7 +13,8 @@ import java.util.List;
 import java.util.Objects;
 
 /** Provides base functionality for making JavaParser-based changes based on Sonar results. */
-public abstract class SonarPluginJavaParserChanger<T extends Node> extends JavaParserChanger {
+public abstract class SonarPluginJavaParserChanger<T extends Node> extends JavaParserChanger
+    implements FixOnlyCodeChanger {
 
   private final RuleIssues ruleIssues;
   private final Class<? extends Node> nodeType;


### PR DESCRIPTION
This adds the `detectionTool` metadata field to the CodeTF result and populates the appropriate `detectionTool` metadata for Sonar codemods. I will create separate issues for updating CodeQL and Semgrep codemods.