### PR TITLE
Remove Sonar commented codemod from defaults

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/DefaultCodemods.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/DefaultCodemods.java
@@ -39,7 +39,6 @@ public final class DefaultCodemods {
         OverridesMatchParentSynchronizationCodemod.class,
         PreventFileWriterLeakWithFilesCodemod.class,
         RandomizeSeedCodemod.class,
-        RemoveCommentedCodeCodemod.class,
         RemoveRedundantVariableCreationCodemod.class,
         RemoveUnusedLocalVariableCodemod.class,
         RemoveUnusedPrivateMethodCodemod.class,

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveCommentedCodeCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveCommentedCodeCodemod.java
@@ -9,7 +9,12 @@ import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
 import io.codemodder.providers.sonar.api.Issue;
 import javax.inject.Inject;
 
-/** A codemod for removing commented-out lines of code. This codemod has dubious value because Sonar often reports a single line out of many consecutive lines that may have code, so removing that particular line will only result in a half-removed commented, which is potentially more confusing. It also false positives when comments start with common coding tokens.  */
+/**
+ * A codemod for removing commented-out lines of code. This codemod has dubious value because Sonar
+ * often reports a single line out of many consecutive lines that may have code, so removing that
+ * particular line will only result in a half-removed commented, which is potentially more
+ * confusing. It also false positives when comments start with common coding tokens.
+ */
 @Codemod(
     id = "sonar:java/remove-commented-code-s125",
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,

--- a/core-codemods/src/main/java/io/codemodder/codemods/RemoveCommentedCodeCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RemoveCommentedCodeCodemod.java
@@ -9,7 +9,7 @@ import io.codemodder.providers.sonar.SonarPluginJavaParserChanger;
 import io.codemodder.providers.sonar.api.Issue;
 import javax.inject.Inject;
 
-/** A codemod for removing commented-out lines of code. */
+/** A codemod for removing commented-out lines of code. This codemod has dubious value because Sonar often reports a single line out of many consecutive lines that may have code, so removing that particular line will only result in a half-removed commented, which is potentially more confusing. It also false positives when comments start with common coding tokens.  */
 @Codemod(
     id = "sonar:java/remove-commented-code-s125",
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,


### PR DESCRIPTION
This codemod has dubious value because Sonar often reports a single line out of many consecutive lines that may have code, so removing that particular line will only result in a half-removed commented, which is potentially more confusing. It also false positives when comments start with common coding tokens. I am disabling it for the time being.