### PR TITLE
Adds remove empty string concatenation transform after sql parameterizer transform call in test

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/DefectDojoSqlInjectionCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/DefectDojoSqlInjectionCodemod.java
@@ -94,9 +94,12 @@ public final class DefectDojoSqlInjectionCodemod extends JavaParserChanger
       SQLParameterizer parameterizer = new SQLParameterizer(methodCallExpr);
 
       if (parameterizer.checkAndFix()) {
-        var maybeMethodDecl = methodCallExpr.findAncestor(CallableDeclaration.class);
+        final var maybeMethodDecl = methodCallExpr.findAncestor(CallableDeclaration.class);
         // Cleanup, removes empty string concatenations and unused variables
         maybeMethodDecl.ifPresent(cd -> ASTTransforms.removeEmptyStringConcatenation(cd));
+        // TODO hits a bug with javaparser, where adding nodes won't result in the correct children
+        // order. This causes the following to remove actually used variables
+        // maybeMethodDecl.ifPresent(md -> ASTTransforms.removeUnusedLocalVariables(md));
 
         DetectorFinding fixedFinding = new DetectorFinding(id, true, null);
         allFindings.add(fixedFinding);

--- a/core-codemods/src/test/resources/defectdojo-sql-injection/SqlInjectionChallenge/SqlInjectionChallenge.java.after
+++ b/core-codemods/src/test/resources/defectdojo-sql-injection/SqlInjectionChallenge/SqlInjectionChallenge.java.after
@@ -65,7 +65,7 @@ public class SqlInjectionChallenge extends AssignmentEndpoint {
 
       try (Connection connection = dataSource.getConnection()) {
         String checkUserQuery =
-            "select userid from sql_challenge_users where userid = ?" + "" + "";
+            "select userid from sql_challenge_users where userid = ?";
         PreparedStatement statement = connection.prepareStatement(checkUserQuery);
         statement.setString(1, username_reg);
         ResultSet resultSet = statement.execute();

--- a/core-codemods/src/test/resources/defectdojo-sql-injection/SqlInjectionLesson8/SqlInjectionLesson8.java.after
+++ b/core-codemods/src/test/resources/defectdojo-sql-injection/SqlInjectionLesson8/SqlInjectionLesson8.java.after
@@ -65,10 +65,7 @@ public class SqlInjectionLesson8 extends AssignmentEndpoint {
     StringBuilder output = new StringBuilder();
     String query =
         "SELECT * FROM employees WHERE last_name = ?"
-            + ""
-            + " AND auth_tan = ?"
-            + ""
-            + "";
+            + " AND auth_tan = ?";
 
     try (Connection connection = dataSource.getConnection()) {
       try {
@@ -154,7 +151,7 @@ query,                 ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDAT
     String time = sdf.format(cal.getTime());
 
     String logQuery =
-        "INSERT INTO access_log (time, action) VALUES (?" + "" + ", ?" + "" + ")";
+        "INSERT INTO access_log (time, action) VALUES (?" + ", ?" + ")";
 
     try {
       PreparedStatement statement = connection.prepareStatement(logQuery, TYPE_SCROLL_SENSITIVE, CONCUR_UPDATABLE);


### PR DESCRIPTION
The removal of empty strings after parameterization by `SQLParameterizer` is now done as a separate transform in `ASTs.RemoveEmptyStringConcatenation`. This PR adds this transformation after the parameterization in the newly added test.