### PR TITLE
Extra cleanup for SQLParameterizer

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizer.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizer.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
  * Contains most of the logic for detecting and fixing parameterizable SQL statements for a given
  * {@link MethodCallExpr}.
  */
-public final class SQLParameterizer {
+final class SQLParameterizer {
 
   private static final String preparedStatementNamePrefix = "stmt";
   private static final String preparedStatementNamePrefixAlternative = "statement";

--- a/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizer.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizer.java
@@ -382,7 +382,7 @@ public final class SQLParameterizer {
    *
    * <p>(3) Change <stmtCreation>.execute*() to pstmt.execute().
    */
-  private void fix(
+  private MethodCallExpr fix(
       final Either<MethodCallExpr, LocalVariableDeclaration> stmtCreation,
       final QueryParameterizer queryParameterizer,
       final MethodCallExpr executeCall) {
@@ -448,16 +448,16 @@ public final class SQLParameterizer {
     executeCall.setScope(new NameExpr(stmtName));
     executeCall.setArguments(new NodeList<>());
 
+    MethodCallExpr pstmtCreation;
     // (2.a)
     if (stmtCreation.isLeft()) {
+      pstmtCreation =
+          new MethodCallExpr(stmtCreation.getLeft().getScope().get(), "prepareStatement", args);
       final var pstmtCreationStmt =
           new ExpressionStmt(
               new VariableDeclarationExpr(
                   new VariableDeclarator(
-                      StaticJavaParser.parseType("PreparedStatement"),
-                      stmtName,
-                      new MethodCallExpr(
-                          stmtCreation.getLeft().getScope().get(), "prepareStatement", args))));
+                      StaticJavaParser.parseType("PreparedStatement"), stmtName, pstmtCreation)));
       ASTTransforms.addStatementBeforeStatement(topStatement, pstmtCreationStmt);
 
       // (2.b)
@@ -476,7 +476,10 @@ public final class SQLParameterizer {
           .getVariableDeclarator()
           .getInitializer()
           .ifPresent(expr -> expr.asMethodCallExpr().setArguments(args));
+      pstmtCreation =
+          stmtCreation.getRight().getVariableDeclarator().getInitializer().get().asMethodCallExpr();
     }
+    return pstmtCreation;
   }
 
   private boolean assignedOrDefinedInScope(NameExpr name, LocalVariableDeclaration lvd) {
@@ -500,13 +503,13 @@ public final class SQLParameterizer {
 
   /**
    * Checks if {@code methodCall} is a query call that needs to be fixed and fixes if that's the
-   * case.
+   * case. If the parameterization happened, returns the PreparedStatement creation.
    */
-  public boolean checkAndFix() {
+  public Optional<MethodCallExpr> checkAndFix() {
     if (executeCall.findCompilationUnit().isPresent()) {
       this.compilationUnit = executeCall.findCompilationUnit().get();
     } else {
-      return false;
+      return Optional.empty();
     }
     // validate the call itself first
     if (isParameterizationCandidate(executeCall) && validateExecuteCall(executeCall).isPresent()) {
@@ -518,7 +521,7 @@ public final class SQLParameterizer {
         final QueryParameterizer queryp;
         // should not be emtpy
         if (executeCall.getArguments().isEmpty()) {
-          return false;
+          return Optional.empty();
         }
         queryp = new QueryParameterizer(executeCall.getArgument(0));
 
@@ -546,13 +549,12 @@ public final class SQLParameterizer {
                             .anyMatch(name -> assignedOrDefinedInScope(name, stmtLVD)));
 
         if (queryp.getInjections().isEmpty() || resolvedInScope || nameInScope) {
-          return false;
+          return Optional.empty();
         }
 
-        fix(stmtObject.get(), queryp, executeCall);
-        return true;
+        return Optional.of(fix(stmtObject.get(), queryp, executeCall));
       }
     }
-    return false;
+    return Optional.empty();
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizerCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizerCodemod.java
@@ -1,10 +1,8 @@
 package io.codemodder.codemods;
 
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import io.codemodder.*;
-import io.codemodder.ast.ASTTransforms;
 import io.codemodder.javaparser.JavaParserChanger;
 import java.util.List;
 import java.util.Optional;
@@ -18,13 +16,7 @@ import java.util.stream.Collectors;
 public final class SQLParameterizerCodemod extends JavaParserChanger {
 
   private Optional<CodemodChange> onNodeFound(final MethodCallExpr methodCallExpr) {
-    if (new SQLParameterizer(methodCallExpr).checkAndFix()) {
-      var maybeMethodDecl = methodCallExpr.findAncestor(CallableDeclaration.class);
-      // Cleanup, removes empty string concatenations and unused variables
-      maybeMethodDecl.ifPresent(cd -> ASTTransforms.removeEmptyStringConcatenation(cd));
-      // TODO hits a bug with javaparser, where adding nodes won't result in the correct children
-      // order. This causes the following to remove actually used variables
-      // maybeMethodDecl.ifPresent(md -> ASTTransforms.removeUnusedLocalVariables(md));
+    if (SQLParameterizerWithCleanup.checkAndFix(methodCallExpr)) {
       return Optional.of(CodemodChange.from(methodCallExpr.getBegin().get().line));
     } else {
       return Optional.empty();

--- a/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizerWithCleanup.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizerWithCleanup.java
@@ -1,0 +1,28 @@
+package io.codemodder.codemods;
+
+import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import io.codemodder.ast.ASTTransforms;
+
+public final class SQLParameterizerWithCleanup {
+
+  public static boolean checkAndFix(final MethodCallExpr methodCallExpr) {
+    var maybeFixed = new SQLParameterizer(methodCallExpr).checkAndFix();
+    if (maybeFixed.isPresent()) {
+      // Cleanup
+      var maybeMethodDecl = methodCallExpr.findAncestor(CallableDeclaration.class);
+      // Remove concatenation with empty strings e.g "first" +  "" -> "first";
+      maybeMethodDecl.ifPresent(cd -> ASTTransforms.removeEmptyStringConcatenation(cd));
+      // TODO hits a bug with javaparser, where adding nodes won't result in the correct children
+      // order. This causes the following to remove actually used variables
+      // maybeMethodDecl.ifPresent(md -> ASTTransforms.removeUnusedLocalVariables(md));
+
+      // Merge concatenated literals, e.g. "first" + " and second" -> "first and second"
+      maybeFixed
+          .flatMap(mce -> mce.getArguments().getFirst())
+          .ifPresent(arg -> ASTTransforms.mergeConcatenatedLiterals(arg));
+      return true;
+    }
+    return false;
+  }
+}

--- a/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizerWithCleanup.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizerWithCleanup.java
@@ -6,6 +6,8 @@ import io.codemodder.ast.ASTTransforms;
 
 public final class SQLParameterizerWithCleanup {
 
+  private SQLParameterizerWithCleanup() {}
+
   public static boolean checkAndFix(final MethodCallExpr methodCallExpr) {
     var maybeFixed = new SQLParameterizer(methodCallExpr).checkAndFix();
     if (maybeFixed.isPresent()) {

--- a/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizerWithCleanup.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizerWithCleanup.java
@@ -12,7 +12,7 @@ public final class SQLParameterizerWithCleanup {
       // Cleanup
       var maybeMethodDecl = methodCallExpr.findAncestor(CallableDeclaration.class);
       // Remove concatenation with empty strings e.g "first" +  "" -> "first";
-      maybeMethodDecl.ifPresent(cd -> ASTTransforms.removeEmptyStringConcatenation(cd));
+      maybeMethodDecl.ifPresent(ASTTransforms::removeEmptyStringConcatenation);
       // TODO hits a bug with javaparser, where adding nodes won't result in the correct children
       // order. This causes the following to remove actually used variables
       // maybeMethodDecl.ifPresent(md -> ASTTransforms.removeUnusedLocalVariables(md));
@@ -20,7 +20,7 @@ public final class SQLParameterizerWithCleanup {
       // Merge concatenated literals, e.g. "first" + " and second" -> "first and second"
       maybeFixed
           .flatMap(mce -> mce.getArguments().getFirst())
-          .ifPresent(arg -> ASTTransforms.mergeConcatenatedLiterals(arg));
+          .ifPresent(ASTTransforms::mergeConcatenatedLiterals);
       return true;
     }
     return false;

--- a/core-codemods/src/test/resources/defectdojo-sql-injection/SqlInjectionLesson8/SqlInjectionLesson8.java.after
+++ b/core-codemods/src/test/resources/defectdojo-sql-injection/SqlInjectionLesson8/SqlInjectionLesson8.java.after
@@ -64,8 +64,7 @@ public class SqlInjectionLesson8 extends AssignmentEndpoint {
   protected AttackResult injectableQueryConfidentiality(String name, String auth_tan) {
     StringBuilder output = new StringBuilder();
     String query =
-        "SELECT * FROM employees WHERE last_name = ?"
-            + " AND auth_tan = ?";
+        "SELECT * FROM employees WHERE last_name = ? AND auth_tan = ?";
 
     try (Connection connection = dataSource.getConnection()) {
       try {
@@ -151,7 +150,7 @@ query,                 ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDAT
     String time = sdf.format(cal.getTime());
 
     String logQuery =
-        "INSERT INTO access_log (time, action) VALUES (?" + ", ?" + ")";
+        "INSERT INTO access_log (time, action) VALUES (?, ?)";
 
     try {
       PreparedStatement statement = connection.prepareStatement(logQuery, TYPE_SCROLL_SENSITIVE, CONCUR_UPDATABLE);

--- a/core-codemods/src/test/resources/sql-parameterizer/Test.java.after
+++ b/core-codemods/src/test/resources/sql-parameterizer/Test.java.after
@@ -55,7 +55,7 @@ public final class Test {
   }
 
   public ResultSet stringAfterQuote(String input, String input2) throws SQLException {
-    String sql = "SELECT * FROM USERS WHERE USER = ?" + " AND PHONE=?";
+    String sql = "SELECT * FROM USERS WHERE USER = ? AND PHONE=?";
     PreparedStatement stmt = conn.prepareStatement(sql);
     stmt.setString(1, "user_" + input + "_name");
     stmt.setString(2, input2);

--- a/framework/codemodder-base/src/main/java/io/codemodder/ast/ASTTransforms.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/ast/ASTTransforms.java
@@ -222,10 +222,7 @@ public final class ASTTransforms {
   private static boolean isEmptyString(final Expression expr) {
     // TODO declared as empty with one assignment
     var resolved = ASTs.resolveLocalExpression(expr);
-    if (resolved.isStringLiteralExpr() && resolved.asStringLiteralExpr().getValue().equals("")) {
-      return true;
-    }
-    return false;
+    return resolved.isStringLiteralExpr() && resolved.asStringLiteralExpr().getValue().isEmpty();
   }
 
   /**
@@ -256,7 +253,8 @@ public final class ASTTransforms {
 
   /** Removes all concatenations with empty strings in the given subtree. */
   public static void removeEmptyStringConcatenation(Node subtree) {
-    subtree.findAll(BinaryExpr.class, Node.TreeTraversal.POSTORDER).stream()
+    subtree
+        .findAll(BinaryExpr.class, Node.TreeTraversal.POSTORDER)
         .forEach(binexp -> binexp.replace(removeEmptyStringConcatenation(binexp)));
   }
 
@@ -271,7 +269,7 @@ public final class ASTTransforms {
         var lvd = maybelvd.get();
         var allReferences = ASTs.findAllReferences(lvd);
         // No references?
-        if (allReferences.size() == 0) {
+        if (allReferences.isEmpty()) {
           maybelvd.get().getStatement().remove();
         }
 
@@ -282,7 +280,7 @@ public final class ASTTransforms {
             if (allAssignments.size() == 1) {
               var aexprStmt =
                   Optional.of(allAssignments.get(0))
-                      .flatMap(ae -> ae.getParentNode())
+                      .flatMap(Node::getParentNode)
                       .map(p -> p instanceof ExpressionStmt ? (ExpressionStmt) p : null);
               if (aexprStmt.isPresent()) {
                 aexprStmt.get().remove();

--- a/framework/codemodder-base/src/main/java/io/codemodder/ast/ASTTransforms.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/ast/ASTTransforms.java
@@ -295,19 +295,23 @@ public final class ASTTransforms {
     }
   }
 
-  private static Optional<StringLiteralExpr> removeAndReturnRightmostExpression(final BinaryExpr binExpr){
-	  if (binExpr.getRight().isStringLiteralExpr()){
-		  var right = binExpr.asBinaryExpr().getRight().asStringLiteralExpr();
-		  binExpr.replace(binExpr.getLeft());
-		  return Optional.of(right);
-	  }
-	  if (binExpr.isStringLiteralExpr()){
-		  return Optional.of(binExpr.asStringLiteralExpr());
-	  }
-	  return Optional.empty();
+  private static Optional<StringLiteralExpr> removeAndReturnRightmostExpression(
+      final BinaryExpr binExpr) {
+    if (binExpr.getRight().isStringLiteralExpr()) {
+      var right = binExpr.asBinaryExpr().getRight().asStringLiteralExpr();
+      binExpr.replace(binExpr.getLeft());
+      return Optional.of(right);
+    }
+    if (binExpr.isStringLiteralExpr()) {
+      return Optional.of(binExpr.asStringLiteralExpr());
+    }
+    return Optional.empty();
   }
 
-  /** Given a string expression, merge any literals that are directly concatenated. This transform will recurse over any Names referenced. */
+  /**
+   * Given a string expression, merge any literals that are directly concatenated. This transform
+   * will recurse over any Names referenced.
+   */
   public static void mergeConcatenatedLiterals(final Expression e) {
     // EnclosedExpr and BinaryExpr are considered as internal nodes, so we recurse
     if (e instanceof EnclosedExpr) {
@@ -322,17 +326,23 @@ public final class ASTTransforms {
         && e.asBinaryExpr().getOperator().equals(BinaryExpr.Operator.PLUS)) {
       mergeConcatenatedLiterals(e.asBinaryExpr().getLeft());
       mergeConcatenatedLiterals(e.asBinaryExpr().getRight());
-    var left = e.asBinaryExpr().getLeft();
-    var right = e.asBinaryExpr().getRight();
+      var left = e.asBinaryExpr().getLeft();
+      var right = e.asBinaryExpr().getRight();
 
-      if (right.isStringLiteralExpr()){
-	      if (left.isStringLiteralExpr()){
-	      e.replace(new StringLiteralExpr(left.asStringLiteralExpr().getValue() + right.asStringLiteralExpr().getValue()));
-	      }
-	      if (left.isBinaryExpr()){
-	      var maybeLiteral = removeAndReturnRightmostExpression(left.asBinaryExpr());
-	      maybeLiteral.ifPresent(sl -> right.replace(new StringLiteralExpr(sl.getValue() + right.asStringLiteralExpr().getValue())));
-	      }
+      if (right.isStringLiteralExpr()) {
+        if (left.isStringLiteralExpr()) {
+          e.replace(
+              new StringLiteralExpr(
+                  left.asStringLiteralExpr().getValue() + right.asStringLiteralExpr().getValue()));
+        }
+        if (left.isBinaryExpr()) {
+          var maybeLiteral = removeAndReturnRightmostExpression(left.asBinaryExpr());
+          maybeLiteral.ifPresent(
+              sl ->
+                  right.replace(
+                      new StringLiteralExpr(
+                          sl.getValue() + right.asStringLiteralExpr().getValue())));
+        }
       }
 
     }

--- a/framework/codemodder-base/src/test/java/io/codemodder/ast/MergeConcatenatedLiteralsTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/ast/MergeConcatenatedLiteralsTest.java
@@ -5,18 +5,15 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.VariableDeclarator;
-import io.codemodder.ast.ASTTransforms;
 import io.codemodder.javaparser.JavaParserFactory;
-
 import java.io.IOException;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 
 final class MergeConcatenatedLiteralsTest {
 
   @Test
-  void it_merge_concatenated_literals() throws IOException{
+  void it_merge_concatenated_literals() throws IOException {
     String code =
         """
     class A{
@@ -32,11 +29,10 @@ final class MergeConcatenatedLiteralsTest {
     var expression = node.getInitializer().get();
     ASTTransforms.mergeConcatenatedLiterals(expression);
     assertThat(node.getInitializer().get().toString(), equalTo("a + \"3\" + b + \"789\""));
-
   }
 
   @Test
-  void it_leaves_enclosed_expressions_alone() throws IOException{
+  void it_leaves_enclosed_expressions_alone() throws IOException {
     String code =
         """
     class A{
@@ -52,10 +48,10 @@ final class MergeConcatenatedLiteralsTest {
     var expression = node.getInitializer().get();
     ASTTransforms.mergeConcatenatedLiterals(expression);
     assertThat(node.getInitializer().get().toString(), equalTo("(\"12\") + \"34\""));
-
   }
+
   @Test
-  void it_merges_referenced_literals_in_referenced_variable() throws IOException{
+  void it_merges_referenced_literals_in_referenced_variable() throws IOException {
     String code =
         """
     class A{
@@ -72,6 +68,5 @@ final class MergeConcatenatedLiteralsTest {
     var s = cu.findAll(VariableDeclarator.class).get(1);
     ASTTransforms.mergeConcatenatedLiterals(s.getInitializer().get());
     assertThat(a.getInitializer().get().toString(), equalTo("\"12\""));
-
   }
 }

--- a/framework/codemodder-base/src/test/java/io/codemodder/ast/MergeConcatenatedLiteralsTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/ast/MergeConcatenatedLiteralsTest.java
@@ -1,0 +1,77 @@
+package io.codemodder.ast;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import io.codemodder.ast.ASTTransforms;
+import io.codemodder.javaparser.JavaParserFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+final class MergeConcatenatedLiteralsTest {
+
+  @Test
+  void it_merge_concatenated_literals() throws IOException{
+    String code =
+        """
+    class A{
+	    void f(String a, String b){
+		    String s =  a  + "3" + b + "7" + "8" + "9";
+	    }
+    }
+    """;
+    CompilationUnit cu =
+        JavaParserFactory.newFactory().create(List.of()).parse(code).getResult().get();
+    // var name = cu.findAll(NameExpr.class).get(1);
+    var node = cu.findAll(VariableDeclarator.class).get(0);
+    var expression = node.getInitializer().get();
+    ASTTransforms.mergeConcatenatedLiterals(expression);
+    assertThat(node.getInitializer().get().toString(), equalTo("a + \"3\" + b + \"789\""));
+
+  }
+
+  @Test
+  void it_leaves_enclosed_expressions_alone() throws IOException{
+    String code =
+        """
+    class A{
+	    void f(String a, String b){
+		    String s =  ("1" + "2") + "3" + "4";
+	    }
+    }
+    """;
+    CompilationUnit cu =
+        JavaParserFactory.newFactory().create(List.of()).parse(code).getResult().get();
+    // var name = cu.findAll(NameExpr.class).get(1);
+    var node = cu.findAll(VariableDeclarator.class).get(0);
+    var expression = node.getInitializer().get();
+    ASTTransforms.mergeConcatenatedLiterals(expression);
+    assertThat(node.getInitializer().get().toString(), equalTo("(\"12\") + \"34\""));
+
+  }
+  @Test
+  void it_merges_referenced_literals_in_referenced_variable() throws IOException{
+    String code =
+        """
+    class A{
+	    void f(){
+		    String a =  "1" + "2";
+		    String s =  a;
+	    }
+    }
+    """;
+    CompilationUnit cu =
+        JavaParserFactory.newFactory().create(List.of()).parse(code).getResult().get();
+    // var name = cu.findAll(NameExpr.class).get(1);
+    var a = cu.findAll(VariableDeclarator.class).get(0);
+    var s = cu.findAll(VariableDeclarator.class).get(1);
+    ASTTransforms.mergeConcatenatedLiterals(s.getInitializer().get());
+    assertThat(a.getInitializer().get().toString(), equalTo("\"12\""));
+
+  }
+}


### PR DESCRIPTION
Adds:
- A new transformation for replacing concatenations of string literals with a single literal.
- The aforementioned transformation as a cleanup step for SQLParameterizer.
- A new transformation that combines the SQLParamterizer with the extra cleanup steps.

Closes #300 and #327.