### PR TITLE
:wrench: configure nexus plugin to try 100 times rather than 60 times due to timeouts waiting for resository to transition

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.Duration
+
 plugins {
     alias(buildlibs.plugins.nexus.publish)
     id("io.codemodder.base")
@@ -9,6 +11,10 @@ nexusPublishing {
             nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
             snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
         }
+    }
+    transitionCheckOptions {
+        maxRetries.set(80) // default is 60 but we've been seeing timeouts
+        delayBetween.set(Duration.ofSeconds(30)) // default is 10 seconds
     }
 }
 


### PR DESCRIPTION
See https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#retries-for-state-transitions


There isn't a "timeout" exactly but rather a backoff and a max number of times that can be configured for awaiting repository state change. I didn't see a reason to change the `delayBetween` value because it won't impact the CI minutes used when releasing, but if we try more times we effectively increase the length of time we'll wait for the repository to transition