### PR TITLE
Populate detectionTool metadata for Semgrep codemods

### DIFF
--- a/community-codemods/src/main/java/io/codemodder/examples/MakeJUnit5TestsFinalCodemod.java
+++ b/community-codemods/src/main/java/io/codemodder/examples/MakeJUnit5TestsFinalCodemod.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import io.codemodder.*;
 import io.codemodder.codetf.CodeTFReference;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.nio.file.Path;
@@ -18,7 +19,8 @@ import javax.inject.Inject;
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
     importance = Importance.LOW)
 public final class MakeJUnit5TestsFinalCodemod
-    extends SarifPluginJavaParserChanger<ClassOrInterfaceDeclaration> {
+    extends SarifPluginJavaParserChanger<ClassOrInterfaceDeclaration>
+    implements FixOnlyCodeChanger {
 
   private static final String DETECTION_RULE =
       """
@@ -73,5 +75,18 @@ public final class MakeJUnit5TestsFinalCodemod
   @Override
   public String getIndividualChangeDescription(final Path filePath, final CodemodChange change) {
     return "Made class final";
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "make-junit5-tests-final",
+        "JUnit 5 tests should be final",
+        "https://github.com/HugoMatilla/Effective-JAVA-Summary#17-design-and-document-for-inheritance-or-else-prohibit-it");
   }
 }

--- a/community-codemods/src/main/java/io/codemodder/examples/MakeJUnit5TestsPackagePrivateCodemod.java
+++ b/community-codemods/src/main/java/io/codemodder/examples/MakeJUnit5TestsPackagePrivateCodemod.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import io.codemodder.*;
 import io.codemodder.codetf.CodeTFReference;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.nio.file.Path;
@@ -18,7 +19,8 @@ import javax.inject.Inject;
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
     importance = Importance.LOW)
 public final class MakeJUnit5TestsPackagePrivateCodemod
-    extends SarifPluginJavaParserChanger<ClassOrInterfaceDeclaration> {
+    extends SarifPluginJavaParserChanger<ClassOrInterfaceDeclaration>
+    implements FixOnlyCodeChanger {
 
   private static final String DETECTION_RULE =
       """
@@ -71,5 +73,18 @@ public final class MakeJUnit5TestsPackagePrivateCodemod
   @Override
   public String getIndividualChangeDescription(final Path filePath, final CodemodChange change) {
     return "Made class package private";
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "make-junit5-tests-package-private",
+        "JUnit 5 tests should be package-private",
+        "https://github.com/junit-team/junit5/issues/679");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/DisableAutomaticDirContextDeserializationCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/DisableAutomaticDirContextDeserializationCodemod.java
@@ -5,6 +5,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.BooleanLiteralExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import javax.inject.Inject;
@@ -15,7 +16,7 @@ import javax.inject.Inject;
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW)
 public final class DisableAutomaticDirContextDeserializationCodemod
-    extends SarifPluginJavaParserChanger<ObjectCreationExpr> {
+    extends SarifPluginJavaParserChanger<ObjectCreationExpr> implements FixOnlyCodeChanger {
 
   @Inject
   public DisableAutomaticDirContextDeserializationCodemod(
@@ -31,5 +32,18 @@ public final class DisableAutomaticDirContextDeserializationCodemod
       final Result result) {
     objectCreationExpr.setArgument(4, new BooleanLiteralExpr(false));
     return ChangesResult.changesApplied;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "disable-dircontext-deserialization",
+        "Harden LDAP call against deserialization attacks",
+        "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/FixUnsafeNIOPathComparisonCodemod.java
@@ -7,6 +7,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.util.Optional;
@@ -18,7 +19,7 @@ import javax.inject.Inject;
     importance = Importance.MEDIUM,
     reviewGuidance = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW)
 public final class FixUnsafeNIOPathComparisonCodemod
-    extends SarifPluginJavaParserChanger<MethodCallExpr> {
+    extends SarifPluginJavaParserChanger<MethodCallExpr> implements FixOnlyCodeChanger {
 
   private static final String RULE =
       """
@@ -72,5 +73,18 @@ public final class FixUnsafeNIOPathComparisonCodemod
     methodCallExpr.setArgument(0, newParentArgument);
 
     return ChangesResult.changesApplied;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "fix-unsafe-nio-path-comparison",
+        "Fix unsafe NIO path comparison",
+        "https://codeql.github.com/codeql-query-help/java/java-partial-path-traversal-from-remote/");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/HardenJavaDeserializationCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/HardenJavaDeserializationCodemod.java
@@ -15,6 +15,7 @@ import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.stmt.TryStmt;
 import io.codemodder.*;
 import io.codemodder.ast.ASTTransforms;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import io.github.pixee.security.ObjectInputFilters;
@@ -46,7 +47,7 @@ public final class HardenJavaDeserializationCodemod extends CompositeJavaParserC
    * }</pre>
    */
   private static class AnonymousDeserializationShapeChanger
-      extends SarifPluginJavaParserChanger<ObjectCreationExpr> {
+      extends SarifPluginJavaParserChanger<ObjectCreationExpr> implements FixOnlyCodeChanger {
 
     @Inject
     public AnonymousDeserializationShapeChanger(
@@ -70,10 +71,23 @@ public final class HardenJavaDeserializationCodemod extends CompositeJavaParserC
           .withSameArguments();
       return ChangesResult.changesAppliedWith(List.of(DependencyGAV.JAVA_SECURITY_TOOLKIT));
     }
+
+    @Override
+    public String vendorName() {
+      return "Semgrep";
+    }
+
+    @Override
+    public DetectorRule getDetectorRule() {
+      return new DetectorRule(
+          "harden-java-deserialization",
+          "Introduce protections against deserialization attacks",
+          "https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html");
+    }
   }
 
   private static final class VariableDeclarationDeserializationShapeChanger
-      extends SarifPluginJavaParserChanger<VariableDeclarator> {
+      extends SarifPluginJavaParserChanger<VariableDeclarator> implements FixOnlyCodeChanger {
 
     @Inject
     public VariableDeclarationDeserializationShapeChanger(
@@ -83,6 +97,19 @@ public final class HardenJavaDeserializationCodemod extends CompositeJavaParserC
           VariableDeclarator.class,
           RegionNodeMatcher.MATCHES_START,
           CodemodReporterStrategy.empty());
+    }
+
+    @Override
+    public String vendorName() {
+      return "Semgrep";
+    }
+
+    @Override
+    public DetectorRule getDetectorRule() {
+      return new DetectorRule(
+          "harden-java-deserialization",
+          "Introduce protections against deserialization attacks",
+          "https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html");
     }
 
     @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/HardenProcessCreationCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/HardenProcessCreationCodemod.java
@@ -12,6 +12,7 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import io.codemodder.*;
 import io.codemodder.ast.ASTTransforms;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import io.github.pixee.security.SystemCommand;
@@ -23,13 +24,26 @@ import javax.inject.Inject;
     id = "pixee:java/harden-process-creation",
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
-public final class HardenProcessCreationCodemod
-    extends SarifPluginJavaParserChanger<MethodCallExpr> {
+public final class HardenProcessCreationCodemod extends SarifPluginJavaParserChanger<MethodCallExpr>
+    implements FixOnlyCodeChanger {
 
   @Inject
   public HardenProcessCreationCodemod(
       @SemgrepScan(ruleId = "harden-process-creation") final RuleSarif sarif) {
     super(sarif, MethodCallExpr.class);
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "harden-process-creation",
+        "Introduce protections against system command injection",
+        "https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/HardenXMLDecoderCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/HardenXMLDecoderCodemod.java
@@ -7,6 +7,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import io.github.pixee.security.XMLDecoderSecurity;
@@ -18,13 +19,26 @@ import javax.inject.Inject;
     id = "pixee:java/harden-xmldecoder-stream",
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
-public final class HardenXMLDecoderCodemod
-    extends SarifPluginJavaParserChanger<ObjectCreationExpr> {
+public final class HardenXMLDecoderCodemod extends SarifPluginJavaParserChanger<ObjectCreationExpr>
+    implements FixOnlyCodeChanger {
 
   @Inject
   public HardenXMLDecoderCodemod(
       @SemgrepScan(ruleId = "harden-xmldecoder-stream") final RuleSarif sarif) {
     super(sarif, ObjectCreationExpr.class);
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "harden-xmldecoder-stream",
+        "Harden XMLDecoder usage to prevent common attacks",
+        "https://github.com/mgeeky/Penetration-Testing-Tools/blob/master/web/java-XMLDecoder-RCE.md");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/HardenXMLInputFactoryCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/HardenXMLInputFactoryCodemod.java
@@ -7,6 +7,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import io.github.pixee.security.XMLInputFactorySecurity;
@@ -19,12 +20,25 @@ import javax.inject.Inject;
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
 public final class HardenXMLInputFactoryCodemod
-    extends SarifPluginJavaParserChanger<VariableDeclarator> {
+    extends SarifPluginJavaParserChanger<VariableDeclarator> implements FixOnlyCodeChanger {
 
   @Inject
   public HardenXMLInputFactoryCodemod(
       @SemgrepScan(ruleId = "harden-xmlinputfactory") final RuleSarif sarif) {
     super(sarif, VariableDeclarator.class, RegionNodeMatcher.MATCHES_START);
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "harden-xmlinputfactory",
+        "Introduce protections against XXE attacks",
+        "https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/HardenXStreamCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/HardenXStreamCodemod.java
@@ -13,6 +13,7 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.zafarkhaja.semver.Version;
 import io.codemodder.*;
 import io.codemodder.ast.ASTTransforms;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.util.List;
@@ -26,11 +27,25 @@ import org.slf4j.LoggerFactory;
     id = "pixee:java/harden-xstream",
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
-public final class HardenXStreamCodemod extends SarifPluginJavaParserChanger<VariableDeclarator> {
+public final class HardenXStreamCodemod extends SarifPluginJavaParserChanger<VariableDeclarator>
+    implements FixOnlyCodeChanger {
 
   @Inject
   public HardenXStreamCodemod(@SemgrepScan(ruleId = "harden-xstream") final RuleSarif sarif) {
     super(sarif, VariableDeclarator.class, RegionNodeMatcher.MATCHES_START);
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "harden-xstream",
+        "Harden XStream with a converter to prevent exploitation",
+        "https://www.contrastsecurity.com/security-influencers/serialization-must-die-act-2-xstream");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/HardenZipEntryPathsCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/HardenZipEntryPathsCodemod.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.*;
 import io.codemodder.*;
 import io.codemodder.ast.ASTTransforms;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import io.github.pixee.security.ZipSecurity;
@@ -18,7 +19,7 @@ import javax.inject.Inject;
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
 public final class HardenZipEntryPathsCodemod
-    extends SarifPluginJavaParserChanger<VariableDeclarator> {
+    extends SarifPluginJavaParserChanger<VariableDeclarator> implements FixOnlyCodeChanger {
 
   @Inject
   public HardenZipEntryPathsCodemod(
@@ -41,5 +42,18 @@ public final class HardenZipEntryPathsCodemod
     variableDeclarator.setInitializer(securedCall);
     ASTTransforms.addImportIfMissing(cu, ZipSecurity.class);
     return ChangesResult.changesAppliedWith(List.of(DependencyGAV.JAVA_SECURITY_TOOLKIT));
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "harden-zip-entry-paths",
+        "Introduce protections against \"zip slip\" attacks",
+        "https://snyk.io/research/zip-slip-vulnerability");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/LimitReadlineCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/LimitReadlineCodemod.java
@@ -10,6 +10,7 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import io.codemodder.*;
 import io.codemodder.ast.ASTTransforms;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import io.github.pixee.security.BoundedLineReader;
@@ -22,7 +23,8 @@ import javax.inject.Inject;
     id = "pixee:java/limit-readline",
     importance = Importance.MEDIUM,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
-public final class LimitReadlineCodemod extends SarifPluginJavaParserChanger<MethodCallExpr> {
+public final class LimitReadlineCodemod extends SarifPluginJavaParserChanger<MethodCallExpr>
+    implements FixOnlyCodeChanger {
 
   private final Parameter limit;
 
@@ -40,6 +42,19 @@ public final class LimitReadlineCodemod extends SarifPluginJavaParserChanger<Met
           final Parameter limit) {
     super(sarif, MethodCallExpr.class);
     this.limit = Objects.requireNonNull(limit);
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "limit-readline",
+        "Protect `readLine()` against DoS",
+        "https://vulncat.fortify.com/en/detail?id=desc.dataflow.abap.denial_of_service");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/LogFailedLoginCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/LogFailedLoginCodemod.java
@@ -7,6 +7,7 @@ import com.github.difflib.patch.AbstractDelta;
 import com.github.difflib.patch.InsertDelta;
 import com.github.difflib.patch.Patch;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.plugins.llm.OpenAIService;
 import io.codemodder.plugins.llm.SarifToLLMForBinaryVerificationAndFixingCodemod;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
@@ -17,12 +18,26 @@ import javax.inject.Inject;
     id = "pixee:java/log-failed-login",
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_AFTER_REVIEW)
-public final class LogFailedLoginCodemod extends SarifToLLMForBinaryVerificationAndFixingCodemod {
+public final class LogFailedLoginCodemod extends SarifToLLMForBinaryVerificationAndFixingCodemod
+    implements FixOnlyCodeChanger {
 
   @Inject
   public LogFailedLoginCodemod(
       @SemgrepScan(ruleId = "log-failed-login") final RuleSarif sarif, final OpenAIService openAI) {
     super(sarif, openAI);
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "log-failed-login",
+        "Log failed login attempts",
+        "https://security.stackexchange.com/a/147261");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/MigrateFilesCommonsIOToNIOCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/MigrateFilesCommonsIOToNIOCodemod.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.util.Objects;
@@ -80,7 +81,7 @@ public final class MigrateFilesCommonsIOToNIOCodemod extends CompositeJavaParser
   }
 
   private abstract static class CommonsToNIOToPathChanger
-      extends SarifPluginJavaParserChanger<MethodCallExpr> {
+      extends SarifPluginJavaParserChanger<MethodCallExpr> implements FixOnlyCodeChanger {
     private final String methodName;
 
     private CommonsToNIOToPathChanger(final RuleSarif ruleSarif, final String methodName) {
@@ -105,6 +106,19 @@ public final class MigrateFilesCommonsIOToNIOCodemod extends CompositeJavaParser
       }
 
       return success ? ChangesResult.changesApplied : ChangesResult.noChanges;
+    }
+
+    @Override
+    public String vendorName() {
+      return "Semgrep";
+    }
+
+    @Override
+    public DetectorRule getDetectorRule() {
+      return new DetectorRule(
+          "migrate-files-commons-io-to-nio",
+          "Migrate Apache `commons-io` APIs to Java's NIO",
+          "https://itsallbinary.com/reading-file-to-string-in-java-with-performance-io-nio-apache-commons-io-google-guava/");
     }
 
     /**

--- a/core-codemods/src/main/java/io/codemodder/codemods/MigrateSpringJobBuilderFactoryCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/MigrateSpringJobBuilderFactoryCodemod.java
@@ -16,6 +16,7 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.util.List;
@@ -28,7 +29,7 @@ import javax.inject.Inject;
     importance = Importance.LOW,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
 public final class MigrateSpringJobBuilderFactoryCodemod
-    extends SarifPluginJavaParserChanger<MethodCallExpr> {
+    extends SarifPluginJavaParserChanger<MethodCallExpr> implements FixOnlyCodeChanger {
 
   private static final String RULE =
       """
@@ -51,6 +52,19 @@ public final class MigrateSpringJobBuilderFactoryCodemod
   @Inject
   public MigrateSpringJobBuilderFactoryCodemod(@SemgrepScan(yaml = RULE) RuleSarif sarif) {
     super(sarif, MethodCallExpr.class);
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "migrate-spring-job-builder-factory",
+        "Migrate Spring JobBuilderFactory",
+        "https://docs.spring.io/spring-batch/docs/current/api/org/springframework/batch/core/configuration/annotation/JobBuilderFactory.html");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/OptimizeJacksonStringUsageCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/OptimizeJacksonStringUsageCodemod.java
@@ -12,6 +12,7 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import io.codemodder.*;
 import io.codemodder.ast.ASTs;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.util.Optional;
@@ -22,7 +23,7 @@ import javax.inject.Inject;
     importance = Importance.MEDIUM,
     reviewGuidance = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW)
 public final class OptimizeJacksonStringUsageCodemod
-    extends SarifPluginJavaParserChanger<ExpressionStmt> {
+    extends SarifPluginJavaParserChanger<ExpressionStmt> implements FixOnlyCodeChanger {
 
   @Inject
   public OptimizeJacksonStringUsageCodemod(
@@ -31,6 +32,19 @@ public final class OptimizeJacksonStringUsageCodemod
         semgrepSarif,
         ExpressionStmt.class,
         SourceCodeRegionExtractor.FROM_SARIF_FIRST_THREADFLOW_EVENT);
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "optimize-jackson-string-usage",
+        "Optimize out unnecessary JSON deserialization step",
+        "https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html");
   }
 
   /**

--- a/core-codemods/src/main/java/io/codemodder/codemods/PreventFileWriterLeakWithFilesCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/PreventFileWriterLeakWithFilesCodemod.java
@@ -11,6 +11,7 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.io.File;
@@ -27,7 +28,7 @@ import javax.inject.Inject;
     importance = Importance.MEDIUM,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
 public final class PreventFileWriterLeakWithFilesCodemod
-    extends SarifPluginJavaParserChanger<ObjectCreationExpr> {
+    extends SarifPluginJavaParserChanger<ObjectCreationExpr> implements FixOnlyCodeChanger {
 
   @Inject
   public PreventFileWriterLeakWithFilesCodemod(
@@ -55,5 +56,18 @@ public final class PreventFileWriterLeakWithFilesCodemod
     parent.replace(newBufferedWriterCall, newFilesBufferedWriterCall);
     addImportIfMissing(cu, "java.nio.file.Files");
     return ChangesResult.changesApplied;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "prevent-filewriter-leak-with-nio",
+        "Prevent file descriptor leak and modernize BufferedWriter creation",
+        "https://cwe.mitre.org/data/definitions/775.html");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/RandomizeSeedCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/RandomizeSeedCodemod.java
@@ -7,6 +7,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import javax.inject.Inject;
@@ -16,7 +17,8 @@ import javax.inject.Inject;
     id = "pixee:java/make-prng-seed-unpredictable",
     importance = Importance.LOW,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
-public final class RandomizeSeedCodemod extends SarifPluginJavaParserChanger<MethodCallExpr> {
+public final class RandomizeSeedCodemod extends SarifPluginJavaParserChanger<MethodCallExpr>
+    implements FixOnlyCodeChanger {
 
   @Inject
   public RandomizeSeedCodemod(
@@ -35,5 +37,18 @@ public final class RandomizeSeedCodemod extends SarifPluginJavaParserChanger<Met
     NodeList<Expression> arguments = setSeedCall.getArguments();
     arguments.set(0, safeExpression);
     return ChangesResult.changesApplied;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "make-prng-seed-unpredictable",
+        "Strengthen cipher seed with more unpredictable value",
+        "https://wiki.sei.cmu.edu/confluence/display/c/MSC32-C.+Properly+seed+pseudorandom+number+generators");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/ReplaceDefaultHttpClientCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/ReplaceDefaultHttpClientCodemod.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import javax.inject.Inject;
@@ -22,7 +23,7 @@ import javax.inject.Inject;
     importance = Importance.MEDIUM,
     reviewGuidance = ReviewGuidance.MERGE_AFTER_CURSORY_REVIEW)
 public final class ReplaceDefaultHttpClientCodemod
-    extends SarifPluginJavaParserChanger<ObjectCreationExpr> {
+    extends SarifPluginJavaParserChanger<ObjectCreationExpr> implements FixOnlyCodeChanger {
 
   private static final String RULE =
       """
@@ -49,5 +50,18 @@ public final class ReplaceDefaultHttpClientCodemod
     replace(objectCreationExpr).withExpression(expression);
     addImportIfMissing(cu, "org.apache.http.impl.client.HttpClientBuilder");
     return ChangesResult.changesApplied;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "replace-apache-defaulthttpclient",
+        "Replace deprecated and insecure Apache HTTP client",
+        "https://find-sec-bugs.github.io/bugs.htm#DEFAULT_HTTP_CLIENT");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/SSRFCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SSRFCodemod.java
@@ -7,6 +7,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.*;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import io.github.pixee.security.HostValidator;
@@ -18,11 +19,25 @@ import javax.inject.Inject;
     id = "pixee:java/sandbox-url-creation",
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
-public final class SSRFCodemod extends SarifPluginJavaParserChanger<ObjectCreationExpr> {
+public final class SSRFCodemod extends SarifPluginJavaParserChanger<ObjectCreationExpr>
+    implements FixOnlyCodeChanger {
 
   @Inject
   public SSRFCodemod(@SemgrepScan(ruleId = "sandbox-url-creation") RuleSarif semgrepSarif) {
     super(semgrepSarif, ObjectCreationExpr.class);
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "sandbox-url-creation",
+        "Sandboxed URL creation to prevent SSRF attacks",
+        "https://www.hacksplaining.com/prevention/ssrf");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/SanitizeApacheMultipartFilenameCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SanitizeApacheMultipartFilenameCodemod.java
@@ -6,6 +6,7 @@ import com.contrastsecurity.sarif.Result;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import io.github.pixee.security.Filenames;
@@ -18,7 +19,7 @@ import javax.inject.Inject;
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
 public final class SanitizeApacheMultipartFilenameCodemod
-    extends SarifPluginJavaParserChanger<MethodCallExpr> {
+    extends SarifPluginJavaParserChanger<MethodCallExpr> implements FixOnlyCodeChanger {
 
   @Inject
   public SanitizeApacheMultipartFilenameCodemod(
@@ -41,5 +42,18 @@ public final class SanitizeApacheMultipartFilenameCodemod
     return success
         ? ChangesResult.changesAppliedWith(List.of(DependencyGAV.JAVA_SECURITY_TOOLKIT))
         : ChangesResult.noChanges;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "sanitize-apache-multipart-filename",
+        "Sanitize user-provided file names in HTTP multipart uploads",
+        "https://owasp.org/www-community/vulnerabilities/Unrestricted_File_Upload");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/SanitizeHttpHeaderCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SanitizeHttpHeaderCodemod.java
@@ -7,6 +7,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import io.github.pixee.security.Newlines;
@@ -17,7 +18,8 @@ import javax.inject.Inject;
     id = "pixee:java/strip-http-header-newlines",
     importance = Importance.MEDIUM,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
-public final class SanitizeHttpHeaderCodemod extends SarifPluginJavaParserChanger<MethodCallExpr> {
+public final class SanitizeHttpHeaderCodemod extends SarifPluginJavaParserChanger<MethodCallExpr>
+    implements FixOnlyCodeChanger {
 
   @Inject
   public SanitizeHttpHeaderCodemod(
@@ -37,5 +39,18 @@ public final class SanitizeHttpHeaderCodemod extends SarifPluginJavaParserChange
     return success
         ? ChangesResult.changesAppliedWith(List.of(DependencyGAV.JAVA_SECURITY_TOOLKIT))
         : ChangesResult.noChanges;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "strip-http-header-newlines",
+        "Introduced protections against HTTP header injection / smuggling attacks",
+        "https://www.netsparker.com/blog/web-security/crlf-http-header/");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/SanitizeSpringMultipartFilenameCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SanitizeSpringMultipartFilenameCodemod.java
@@ -6,6 +6,7 @@ import com.contrastsecurity.sarif.Result;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import io.github.pixee.security.Filenames;
@@ -18,7 +19,7 @@ import javax.inject.Inject;
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
 public final class SanitizeSpringMultipartFilenameCodemod
-    extends SarifPluginJavaParserChanger<MethodCallExpr> {
+    extends SarifPluginJavaParserChanger<MethodCallExpr> implements FixOnlyCodeChanger {
   @Inject
   public SanitizeSpringMultipartFilenameCodemod(
       @SemgrepScan(ruleId = "sanitize-spring-multipart-filename") RuleSarif semgrepSarif) {
@@ -38,5 +39,18 @@ public final class SanitizeSpringMultipartFilenameCodemod
             .withStaticMethod(Filenames.class.getName(), "toSimpleFileName", false)
         ? ChangesResult.changesAppliedWith(List.of(DependencyGAV.JAVA_SECURITY_TOOLKIT))
         : ChangesResult.noChanges;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "sanitize-spring-multipart-filename",
+        "Sanitize user-provided file names in HTTP multipart uploads",
+        "https://owasp.org/www-community/vulnerabilities/Unrestricted_File_Upload");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/SecureRandomCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SecureRandomCodemod.java
@@ -6,6 +6,7 @@ import com.contrastsecurity.sarif.Result;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.security.SecureRandom;
@@ -17,7 +18,8 @@ import javax.inject.Inject;
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
     importance = Importance.MEDIUM,
     executionPriority = CodemodExecutionPriority.LOW)
-public final class SecureRandomCodemod extends SarifPluginJavaParserChanger<ObjectCreationExpr> {
+public final class SecureRandomCodemod extends SarifPluginJavaParserChanger<ObjectCreationExpr>
+    implements FixOnlyCodeChanger {
 
   private static final String DETECTION_RULE =
       """
@@ -40,5 +42,18 @@ public final class SecureRandomCodemod extends SarifPluginJavaParserChanger<Obje
     objectCreationExpr.setType("SecureRandom");
     addImportIfMissing(cu, SecureRandom.class.getName());
     return ChangesResult.changesApplied;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "secure-random",
+        "Introduced protections against predictable RNG abuse",
+        "https://owasp.org/www-community/vulnerabilities/Insecure_Randomness");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/SemgrepOverlyPermissiveFilePermissionsCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SemgrepOverlyPermissiveFilePermissionsCodemod.java
@@ -11,6 +11,7 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.ProvidedSemgrepScan;
 import java.util.Optional;
@@ -45,7 +46,7 @@ public final class SemgrepOverlyPermissiveFilePermissionsCodemod
    * PosixFilePermissions.fromString("rwxrwxrwx"));}
    */
   private static final class InlineFromStringChanger
-      extends SarifPluginJavaParserChanger<ExpressionStmt> {
+      extends SarifPluginJavaParserChanger<ExpressionStmt> implements FixOnlyCodeChanger {
 
     private InlineFromStringChanger(final RuleSarif sarif) {
       super(
@@ -82,6 +83,19 @@ public final class SemgrepOverlyPermissiveFilePermissionsCodemod
       }
       return ChangesResult.noChanges;
     }
+
+    @Override
+    public String vendorName() {
+      return "Semgrep";
+    }
+
+    @Override
+    public DetectorRule getDetectorRule() {
+      return new DetectorRule(
+          "java.lang.security.audit.overly-permissive-file-permission.overly-permissive-file-permission",
+          "Fix overly permissive file permissions (issue discovered by Semgrep)",
+          "https://find-sec-bugs.github.io/bugs.htm#OVERLY_PERMISSIVE_FILE_PERMISSION");
+    }
   }
 
   /**
@@ -89,8 +103,8 @@ public final class SemgrepOverlyPermissiveFilePermissionsCodemod
    *
    * <p>{@code var p = Permissions.fromString("rwxrwxrwx")}
    */
-  private static final class FromStringChanger
-      extends SarifPluginJavaParserChanger<ExpressionStmt> {
+  private static final class FromStringChanger extends SarifPluginJavaParserChanger<ExpressionStmt>
+      implements FixOnlyCodeChanger {
     private FromStringChanger(final RuleSarif sarif) {
       super(
           sarif,
@@ -118,6 +132,19 @@ public final class SemgrepOverlyPermissiveFilePermissionsCodemod
       }
       return ChangesResult.noChanges;
     }
+
+    @Override
+    public String vendorName() {
+      return "Semgrep";
+    }
+
+    @Override
+    public DetectorRule getDetectorRule() {
+      return new DetectorRule(
+          "java.lang.security.audit.overly-permissive-file-permission.overly-permissive-file-permission",
+          "Fix overly permissive file permissions (issue discovered by Semgrep)",
+          "https://find-sec-bugs.github.io/bugs.htm#OVERLY_PERMISSIVE_FILE_PERMISSION");
+    }
   }
 
   private static ChangesResult fixFromString(final MethodCallExpr fromStringCall) {
@@ -139,7 +166,7 @@ public final class SemgrepOverlyPermissiveFilePermissionsCodemod
    * java.util.Set#add(Object)} call.
    */
   private static final class PermissionAddCallChanger
-      extends SarifPluginJavaParserChanger<MethodCallExpr> {
+      extends SarifPluginJavaParserChanger<MethodCallExpr> implements FixOnlyCodeChanger {
 
     private PermissionAddCallChanger(final RuleSarif sarif) {
       super(
@@ -168,6 +195,19 @@ public final class SemgrepOverlyPermissiveFilePermissionsCodemod
         return fixAdd(call);
       }
       return ChangesResult.noChanges;
+    }
+
+    @Override
+    public String vendorName() {
+      return "Semgrep";
+    }
+
+    @Override
+    public DetectorRule getDetectorRule() {
+      return new DetectorRule(
+          "java.lang.security.audit.overly-permissive-file-permission.overly-permissive-file-permission",
+          "Fix overly permissive file permissions (issue discovered by Semgrep)",
+          "https://find-sec-bugs.github.io/bugs.htm#OVERLY_PERMISSIVE_FILE_PERMISSION");
     }
 
     private ChangesResult fixAdd(final MethodCallExpr call) {

--- a/core-codemods/src/main/java/io/codemodder/codemods/SensitiveDataLoggingCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SensitiveDataLoggingCodemod.java
@@ -7,6 +7,7 @@ import com.github.difflib.patch.AbstractDelta;
 import com.github.difflib.patch.DeleteDelta;
 import com.github.difflib.patch.Patch;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.plugins.llm.OpenAIService;
 import io.codemodder.plugins.llm.SarifToLLMForBinaryVerificationAndFixingCodemod;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
@@ -19,7 +20,7 @@ import javax.inject.Inject;
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_AFTER_REVIEW)
 public final class SensitiveDataLoggingCodemod
-    extends SarifToLLMForBinaryVerificationAndFixingCodemod {
+    extends SarifToLLMForBinaryVerificationAndFixingCodemod implements FixOnlyCodeChanger {
 
   @Inject
   public SensitiveDataLoggingCodemod(
@@ -49,5 +50,18 @@ public final class SensitiveDataLoggingCodemod
     }
 
     return true;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "sensitive-data-logging",
+        "Remove sensitive data from logs",
+        "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/SwitchToStandardCharsetsCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SwitchToStandardCharsetsCodemod.java
@@ -8,6 +8,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.expr.*;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.nio.charset.Charset;
@@ -28,7 +29,8 @@ public final class SwitchToStandardCharsetsCodemod extends CompositeJavaParserCh
     super(getBytesCodemod, charsetForNameCodemode);
   }
 
-  private static class GetBytesCodemod extends SarifPluginJavaParserChanger<MethodCallExpr> {
+  private static class GetBytesCodemod extends SarifPluginJavaParserChanger<MethodCallExpr>
+      implements FixOnlyCodeChanger {
     private static final String RULE =
         """
                 rules:
@@ -40,6 +42,19 @@ public final class SwitchToStandardCharsetsCodemod extends CompositeJavaParserCh
     @Inject
     private GetBytesCodemod(@SemgrepScan(yaml = RULE) final RuleSarif ruleSarif) {
       super(ruleSarif, MethodCallExpr.class, CodemodReporterStrategy.empty());
+    }
+
+    @Override
+    public String vendorName() {
+      return "Semgrep";
+    }
+
+    @Override
+    public DetectorRule getDetectorRule() {
+      return new DetectorRule(
+          "switch-to-standard-charsets",
+          "Switch to StandardCharsets fields instead of strings",
+          "https://community.sonarsource.com/t/use-standardcharsets-instead-of-charset-names/638");
     }
 
     @Override
@@ -66,7 +81,8 @@ public final class SwitchToStandardCharsetsCodemod extends CompositeJavaParserCh
     }
   }
 
-  private static class CharsetForNameCodemod extends SarifPluginJavaParserChanger<MethodCallExpr> {
+  private static class CharsetForNameCodemod extends SarifPluginJavaParserChanger<MethodCallExpr>
+      implements FixOnlyCodeChanger {
     private static final String RULE =
         """
                 rules:
@@ -78,6 +94,19 @@ public final class SwitchToStandardCharsetsCodemod extends CompositeJavaParserCh
     @Inject
     private CharsetForNameCodemod(@SemgrepScan(yaml = RULE) final RuleSarif ruleSarif) {
       super(ruleSarif, MethodCallExpr.class, CodemodReporterStrategy.empty());
+    }
+
+    @Override
+    public String vendorName() {
+      return "Semgrep";
+    }
+
+    @Override
+    public DetectorRule getDetectorRule() {
+      return new DetectorRule(
+          "switch-to-standard-charsets",
+          "Switch to StandardCharsets fields instead of strings",
+          "https://community.sonarsource.com/t/use-standardcharsets-instead-of-charset-names/638");
     }
 
     @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/UpgradeSSLContextTLSCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/UpgradeSSLContextTLSCodemod.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import javax.inject.Inject;
@@ -18,8 +19,8 @@ import javax.inject.Inject;
     id = "pixee:java/upgrade-sslcontext-tls",
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
-public final class UpgradeSSLContextTLSCodemod
-    extends SarifPluginJavaParserChanger<MethodCallExpr> {
+public final class UpgradeSSLContextTLSCodemod extends SarifPluginJavaParserChanger<MethodCallExpr>
+    implements FixOnlyCodeChanger {
 
   @Inject
   public UpgradeSSLContextTLSCodemod(
@@ -37,5 +38,18 @@ public final class UpgradeSSLContextTLSCodemod
     getInstanceCall.setArguments(
         NodeList.nodeList(new StringLiteralExpr(SSLProtocols.safeTlsVersion)));
     return ChangesResult.changesApplied;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "upgrade-sslcontext-tls",
+        "Upgrad SSLContext#getInstance() TLS versions to match current best practices",
+        "https://datatracker.ietf.org/doc/rfc8996/");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/UpgradeSSLEngineTLSCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/UpgradeSSLEngineTLSCodemod.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.expr.ArrayCreationExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import javax.inject.Inject;
@@ -21,7 +22,8 @@ import javax.inject.Inject;
     id = "pixee:java/upgrade-sslengine-tls",
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
-public final class UpgradeSSLEngineTLSCodemod extends SarifPluginJavaParserChanger<MethodCallExpr> {
+public final class UpgradeSSLEngineTLSCodemod extends SarifPluginJavaParserChanger<MethodCallExpr>
+    implements FixOnlyCodeChanger {
 
   @Inject
   public UpgradeSSLEngineTLSCodemod(
@@ -39,5 +41,18 @@ public final class UpgradeSSLEngineTLSCodemod extends SarifPluginJavaParserChang
         newArray("String", new StringLiteralExpr(SSLProtocols.safeTlsVersion));
     setEnabledProtocolsCall.setArguments(NodeList.nodeList(safeProtocols));
     return ChangesResult.changesApplied;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "upgrade-sslengine-tls",
+        "Upgraded SSLEngine#setEnabledProtocols() TLS versions to match current best practices",
+        "https://datatracker.ietf.org/doc/rfc8996/");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/UpgradeSSLParametersTLSCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/UpgradeSSLParametersTLSCodemod.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.expr.ArrayCreationExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import javax.inject.Inject;
@@ -22,7 +23,7 @@ import javax.inject.Inject;
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
 public final class UpgradeSSLParametersTLSCodemod
-    extends SarifPluginJavaParserChanger<MethodCallExpr> {
+    extends SarifPluginJavaParserChanger<MethodCallExpr> implements FixOnlyCodeChanger {
 
   @Inject
   public UpgradeSSLParametersTLSCodemod(
@@ -40,5 +41,18 @@ public final class UpgradeSSLParametersTLSCodemod
         newArray("String", new StringLiteralExpr(SSLProtocols.safeTlsVersion));
     setEnabledProtocolsCall.setArguments(NodeList.nodeList(safeProtocols));
     return ChangesResult.changesApplied;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "upgrade-sslparameters-tls",
+        "Upgrade SSLParameters#setProtocols() TLS versions to match current best practices",
+        "https://datatracker.ietf.org/doc/rfc8996/");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/UpgradeSSLSocketProtocolsTLSCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/UpgradeSSLSocketProtocolsTLSCodemod.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.expr.ArrayCreationExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import javax.inject.Inject;
@@ -22,7 +23,7 @@ import javax.inject.Inject;
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
 public final class UpgradeSSLSocketProtocolsTLSCodemod
-    extends SarifPluginJavaParserChanger<MethodCallExpr> {
+    extends SarifPluginJavaParserChanger<MethodCallExpr> implements FixOnlyCodeChanger {
 
   @Inject
   public UpgradeSSLSocketProtocolsTLSCodemod(
@@ -40,5 +41,18 @@ public final class UpgradeSSLSocketProtocolsTLSCodemod
         newArray("String", new StringLiteralExpr(SSLProtocols.safeTlsVersion));
     setEnabledProtocolsCall.setArguments(NodeList.nodeList(safeProtocols));
     return ChangesResult.changesApplied;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "upgrade-sslsocket-tls",
+        "Upgrade SSLSocket#setEnabledProtocols() TLS versions to match current best practices",
+        "https://datatracker.ietf.org/doc/rfc8996/");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/UpgradeTempFileToNIOCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/UpgradeTempFileToNIOCodemod.java
@@ -10,6 +10,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.nio.file.Files;
@@ -24,13 +25,26 @@ import javax.inject.Inject;
     id = "pixee:java/upgrade-tempfile-to-nio",
     importance = Importance.MEDIUM,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
-public final class UpgradeTempFileToNIOCodemod
-    extends SarifPluginJavaParserChanger<MethodCallExpr> {
+public final class UpgradeTempFileToNIOCodemod extends SarifPluginJavaParserChanger<MethodCallExpr>
+    implements FixOnlyCodeChanger {
 
   @Inject
   public UpgradeTempFileToNIOCodemod(
       @SemgrepScan(ruleId = "upgrade-tempfile-to-nio") final RuleSarif sarif) {
     super(sarif, MethodCallExpr.class);
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "upgrade-tempfile-to-nio",
+        "Modernize and secure temp file creation",
+        "https://cwe.mitre.org/data/definitions/378.html");
   }
 
   @Override

--- a/core-codemods/src/main/java/io/codemodder/codemods/ValidateJakartaForwardPathCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/ValidateJakartaForwardPathCodemod.java
@@ -6,6 +6,7 @@ import com.contrastsecurity.sarif.Result;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.Expression;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.util.List;
@@ -20,7 +21,7 @@ import javax.inject.Inject;
     importance = Importance.HIGH,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
 public final class ValidateJakartaForwardPathCodemod
-    extends SarifPluginJavaParserChanger<Expression> {
+    extends SarifPluginJavaParserChanger<Expression> implements FixOnlyCodeChanger {
 
   @Inject
   public ValidateJakartaForwardPathCodemod(
@@ -39,5 +40,18 @@ public final class ValidateJakartaForwardPathCodemod
                 "io.github.pixee.security.jakarta.PathValidator", "validateDispatcherPath", true)
         ? ChangesResult.changesAppliedWith(List.of(DependencyGAV.JAVA_SECURITY_TOOLKIT))
         : ChangesResult.noChanges;
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "validate-jakarta-forward-path",
+        "Introduce protections against user-controlled internal request forwarding",
+        "https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html#dangerous-forward-example");
   }
 }

--- a/core-codemods/src/main/java/io/codemodder/codemods/VerboseRequestMappingCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/VerboseRequestMappingCodemod.java
@@ -8,6 +8,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MemberValuePair;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import io.codemodder.*;
+import io.codemodder.codetf.DetectorRule;
 import io.codemodder.javaparser.ChangesResult;
 import io.codemodder.providers.sarif.semgrep.SemgrepScan;
 import java.util.Optional;
@@ -18,12 +19,25 @@ import javax.inject.Inject;
     importance = Importance.LOW,
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW)
 public final class VerboseRequestMappingCodemod
-    extends SarifPluginJavaParserChanger<NormalAnnotationExpr> {
+    extends SarifPluginJavaParserChanger<NormalAnnotationExpr> implements FixOnlyCodeChanger {
 
   @Inject
   public VerboseRequestMappingCodemod(
       @SemgrepScan(ruleId = "verbose-request-mapping") final RuleSarif sarif) {
     super(sarif, NormalAnnotationExpr.class);
+  }
+
+  @Override
+  public String vendorName() {
+    return "Semgrep";
+  }
+
+  @Override
+  public DetectorRule getDetectorRule() {
+    return new DetectorRule(
+        "verbose-request-mapping",
+        "Replaced @RequestMapping annotation with shortcut annotation for requested HTTP Method",
+        "https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-requestmapping.html");
   }
 
   @Override


### PR DESCRIPTION
Populate detectionTool metadata for Semgrep codemods  (`@ProvidedSemgrepScan` and `@SemgrepScan`)

Issue https://github.com/pixee/codemodder-java/issues/314