### PR TITLE
✨ Inspect GitHub Actions Workflow Files By Default

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -626,7 +626,9 @@ final class CLI implements Callable<Integer> {
           "**.jsp",
           "**/*.jsp",
           "web.xml",
-          "**/web.xml");
+          "**/web.xml",
+          ".github/workflows/*.yml",
+          ".github/workflows/*.yaml");
 
   private static final List<String> defaultPathExcludes =
       List.of(


### PR DESCRIPTION
In preparation to add new codemods that affect GitHub Actions workflow files, we should include such files in the default path includes. This is a stop-gap measure until we have a more general way for new codemods to influence the files that codemodder wants to inspect by default.

/towards ISS-834