### PR TITLE
Allow calling public methods on `SQLParameterizer` from outsiders

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizer.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SQLParameterizer.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
  * Contains most of the logic for detecting and fixing parameterizable SQL statements for a given
  * {@link MethodCallExpr}.
  */
-final class SQLParameterizer {
+public final class SQLParameterizer {
 
   private static final String preparedStatementNamePrefix = "stmt";
   private static final String preparedStatementNamePrefixAlternative = "statement";


### PR DESCRIPTION
This type already offers `public` APIs and is used by multiple codemods, so it should be available for all.