### PR TITLE
Add fix for tab-oriented confusion 

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/AddClarifyingBracesCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/AddClarifyingBracesCodemod.java
@@ -95,8 +95,6 @@ public final class AddClarifyingBracesCodemod extends SarifPluginJavaParserChang
   private interface UnbracedStatement {
     Node getParentNode();
 
-    Statement getExistingSingleStatement();
-
     Range getExistingSingleStatementRange();
 
     void addBraces();
@@ -120,11 +118,6 @@ public final class AddClarifyingBracesCodemod extends SarifPluginJavaParserChang
     }
 
     @Override
-    public Statement getExistingSingleStatement() {
-      return whileStmt.getBody();
-    }
-
-    @Override
     public void addBraces() {
       whileStmt.setBody(new BlockStmt(NodeList.nodeList(whileStmt.getBody())));
     }
@@ -143,11 +136,6 @@ public final class AddClarifyingBracesCodemod extends SarifPluginJavaParserChang
     @Override
     public Node getParentNode() {
       return ifStmt.getParentNode().get();
-    }
-
-    @Override
-    public Statement getExistingSingleStatement() {
-      return ifStmt.getThenStmt();
     }
 
     @Override
@@ -179,11 +167,6 @@ public final class AddClarifyingBracesCodemod extends SarifPluginJavaParserChang
     @Override
     public Range getExistingSingleStatementRange() {
       return ifStmt.getElseStmt().get().getRange().get();
-    }
-
-    @Override
-    public Statement getExistingSingleStatement() {
-      return ifStmt.getElseStmt().get();
     }
 
     @Override

--- a/core-codemods/src/test/resources/add-clarifying-braces/BigTabRegression.java.before
+++ b/core-codemods/src/test/resources/add-clarifying-braces/BigTabRegression.java.before
@@ -1,0 +1,12 @@
+package com.acme;
+
+abstract class Foo {
+
+    private void loadApplications() {
+        if(m_authProvider.isTokenExpired())
+			return;
+
+        m_applications = new HashMap<String, String>();
+        String url =  m_authProvider.getServer() + ASE_APPS+"?columns=name";
+	}
+}


### PR DESCRIPTION
This result for the `AddClarifyingBracesCodemod` was confusing, because it shouldn't act on the statement. There's no visual confusion in the single statement within the if block.

The math the codemod does for calculating the offsets involved and deciding to change is based on column number. This makes sense if the code is written with spaces, not tabs. With tabs, the "visual layout" of the code depends on the viewer, and the offsets would require different math at a minimum. Our workaround is to ignore cases that involve tabs for now until we get a better design to accommodate tabs.

<img width="434" alt="image" src="https://github.com/pixee/codemodder-java/assets/911610/9de959b0-d952-42a9-b673-54716a513a47">
