### PR TITLE
🔇 Reduce Noise in Logs

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/DefaultJavaParserFacade.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/DefaultJavaParserFacade.java
@@ -8,8 +8,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
 import javax.inject.Provider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class DefaultJavaParserFacade implements JavaParserFacade {
 
@@ -31,14 +29,11 @@ final class DefaultJavaParserFacade implements JavaParserFacade {
 
     final ParseResult<CompilationUnit> result = parser.parse(file);
     if (!result.isSuccessful()) {
-      logger.error(
-          "Error while parsing file {} encountered problems: {}", file, result.getProblems());
-      throw new RuntimeException("can't parse file");
+      throw new RuntimeException(
+          "Error while parsing file " + file + " encountered problems: " + result.getProblems());
     }
     CompilationUnit cu = result.getResult().orElseThrow();
     LexicalPreservingPrinter.setup(cu);
     return cu;
   }
-
-  private static final Logger logger = LoggerFactory.getLogger(DefaultJavaParserFacade.class);
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/DefaultJavaParserFacade.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/DefaultJavaParserFacade.java
@@ -29,7 +29,7 @@ final class DefaultJavaParserFacade implements JavaParserFacade {
 
     final ParseResult<CompilationUnit> result = parser.parse(file);
     if (!result.isSuccessful()) {
-      throw new RuntimeException(
+      throw new JavaParseException(
           "Error while parsing file " + file + " encountered problems: " + result.getProblems());
     }
     CompilationUnit cu = result.getResult().orElseThrow();

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParseException.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParseException.java
@@ -1,0 +1,10 @@
+package io.codemodder.javaparser;
+
+import java.io.IOException;
+
+/** Exception that indicates a failure to parse a Java file. */
+public class JavaParseException extends IOException {
+  public JavaParseException(final String message) {
+    super(message);
+  }
+}

--- a/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserFacade.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/javaparser/JavaParserFacade.java
@@ -18,7 +18,8 @@ public interface JavaParserFacade {
    * CompilationUnit}.
    *
    * @param file a Java file path
-   * @throws IOException if the file cannot be read
+   * @throws IOException when the file cannot be read and parsed
+   * @throws JavaParseException when the file can be read but fails parsing
    * @return a {@link CompilationUnit} for the given file
    */
   CompilationUnit parseJavaFile(Path file) throws IOException;

--- a/framework/codemodder-base/src/test/java/io/codemodder/javaparser/DefaultJavaParserFacadeTest.java
+++ b/framework/codemodder-base/src/test/java/io/codemodder/javaparser/DefaultJavaParserFacadeTest.java
@@ -54,7 +54,7 @@ final class DefaultJavaParserFacadeTest {
   @Test
   void it_fails_loudly_if_cant_parse() throws IOException {
     Files.writeString(javaFile, "bad code");
-    assertThrows(RuntimeException.class, () -> parser.parseJavaFile(javaFile));
+    assertThrows(JavaParseException.class, () -> parser.parseJavaFile(javaFile));
   }
 
   @Test


### PR DESCRIPTION
When codemodder encounters a text file with a character encoding that it does not support, then it fails to read that file and emits an error level log with a stack trace. This can be very noisy.

Instead, we should emit a warn level log with no stack trace when this occurs. warn feels right for a couple of reasons:

* this error does not prevent codemodder from completing its analysis; rather, codemodder adds the failed file to its "failed files" list in its CodeTF report.
* there will always be cases for which we have no recourse for this problem.

Also, we need to include the file path in the warning message.

/close #work