### PR TITLE
Remove explicit setEntityExpansion calls

### DIFF
--- a/core-codemods/src/test/resources/sonar-xxe-s2755/Test.java.after
+++ b/core-codemods/src/test/resources/sonar-xxe-s2755/Test.java.after
@@ -72,7 +72,6 @@ public class XXEVuln {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
         dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        dbf.setExpandEntityReferences(true);
         DocumentBuilder db = dbf.newDocumentBuilder();
         return db.parse(new InputSource(new StringReader(xml)));
     }

--- a/framework/codemodder-base/src/main/java/io/codemodder/remediation/xxe/DocumentBuilderFactoryAndSAXParserAtCreationFixer.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/remediation/xxe/DocumentBuilderFactoryAndSAXParserAtCreationFixer.java
@@ -44,6 +44,6 @@ final class DocumentBuilderFactoryAndSAXParserAtCreationFixer implements XXEFixe
 
     Statement statement = variableDeclarationStmtRef.get();
     return addFeatureDisablingStatements(
-        cu, newFactoryVariable.getNameAsExpression(), statement, false);
+        newFactoryVariable.getNameAsExpression(), statement, false);
   }
 }

--- a/framework/codemodder-base/src/main/java/io/codemodder/remediation/xxe/DocumentBuilderFactoryAtParseFixer.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/remediation/xxe/DocumentBuilderFactoryAtParseFixer.java
@@ -104,7 +104,7 @@ final class DocumentBuilderFactoryAtParseFixer implements XXEFixer {
             "DocumentBuilder was initialized with a factory call without a statement");
       }
       return XMLFeatures.addFeatureDisablingStatements(
-          cu, factoryNameExpr, newDocumentBuilderStatement.get(), true);
+          factoryNameExpr, newDocumentBuilderStatement.get(), true);
     } else if (parserAssignmentNode instanceof Parameter) {
       return new XXEFixAttempt(true, false, "DocumentBuilder came from outside the method scope");
     }

--- a/framework/codemodder-base/src/main/java/io/codemodder/remediation/xxe/XMLReaderAtParseFixer.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/remediation/xxe/XMLReaderAtParseFixer.java
@@ -72,6 +72,6 @@ final class XMLReaderAtParseFixer implements XXEFixer {
       return new XXEFixAttempt(true, false, "No statement found for parse() call");
     }
     return XMLFeatures.addFeatureDisablingStatements(
-        cu, parser.asNameExpr(), parseStatement.get(), true);
+        parser.asNameExpr(), parseStatement.get(), true);
   }
 }


### PR DESCRIPTION
When fixing XXE, users may find it helpful to also remove explicit turning on off entity expansion.