### PR TITLE
Added support for changing Statement object in assignments.

### DIFF
--- a/core-codemods/src/test/resources/sql-parameterizer/Test.java.after
+++ b/core-codemods/src/test/resources/sql-parameterizer/Test.java.after
@@ -81,4 +81,17 @@ public final class Test {
     var rs = stmt.execute();
     return rs;
   }
+
+  public ResultSet singeAssigned(String input) throws SQLException {
+    String sql = "SELECT * FROM USERS WHERE USER = ?";
+    Statement stmt = conn.createStatement();
+    try {
+      stmt = (Statement) conn.prepareStatement(sql);
+      ((PreparedStatement) stmt).setString(1, input);
+      ResultSet rs = ((PreparedStatement) stmt).execute();
+      return rs;
+    } catch (Exception e) {
+    }
+  }
+
 }

--- a/core-codemods/src/test/resources/sql-parameterizer/Test.java.after
+++ b/core-codemods/src/test/resources/sql-parameterizer/Test.java.after
@@ -82,13 +82,13 @@ public final class Test {
     return rs;
   }
 
-  public ResultSet singeAssigned(String input) throws SQLException {
+  public ResultSet singleAssigned(String input) throws SQLException {
     String sql = "SELECT * FROM USERS WHERE USER = ?";
-    Statement stmt = conn.createStatement();
+    PreparedStatement stmt = null;
     try {
-      stmt = (Statement) conn.prepareStatement(sql);
-      ((PreparedStatement) stmt).setString(1, input);
-      ResultSet rs = ((PreparedStatement) stmt).execute();
+      stmt = conn.prepareStatement(sql);
+      stmt.setString(1, input);
+      ResultSet rs = stmt.execute();
       return rs;
     } catch (Exception e) {
     }

--- a/core-codemods/src/test/resources/sql-parameterizer/Test.java.before
+++ b/core-codemods/src/test/resources/sql-parameterizer/Test.java.before
@@ -66,4 +66,16 @@ public final class Test {
     var rs = stmt.executeQuery(sql);
     return rs;
   }
+
+  public ResultSet singeAssigned(String input) throws SQLException {
+    String sql = "SELECT * FROM USERS WHERE USER = '" + input + "'";
+    Statement stmt = conn.createStatement();
+    try {
+      stmt = conn.createStatement();
+      ResultSet rs = stmt.executeQuery(sql);
+      return rs;
+    } catch (Exception e) {
+    }
+  }
+
 }

--- a/core-codemods/src/test/resources/sql-parameterizer/Test.java.before
+++ b/core-codemods/src/test/resources/sql-parameterizer/Test.java.before
@@ -67,7 +67,7 @@ public final class Test {
     return rs;
   }
 
-  public ResultSet singeAssigned(String input) throws SQLException {
+  public ResultSet singleAssigned(String input) throws SQLException {
     String sql = "SELECT * FROM USERS WHERE USER = '" + input + "'";
     Statement stmt = conn.createStatement();
     try {

--- a/framework/codemodder-base/src/main/java/io/codemodder/ast/ASTs.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/ast/ASTs.java
@@ -33,9 +33,7 @@ public final class ASTs {
 
   private ASTs() {}
 
-  /**
-   * Test for this pattern: {@link ExpressionStmt} -&gt; {@link Expression} ({@code expr}).
-   */
+  /** Test for this pattern: {@link ExpressionStmt} -&gt; {@link Expression} ({@code expr}). */
   public static Optional<ExpressionStmt> isExpressionStmtExpr(final Expression expr) {
     return expr.getParentNode()
         .map(p -> p instanceof ExpressionStmt ? (ExpressionStmt) p : null)

--- a/framework/codemodder-base/src/main/java/io/codemodder/ast/ASTs.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/ast/ASTs.java
@@ -34,6 +34,15 @@ public final class ASTs {
   private ASTs() {}
 
   /**
+   * Test for this pattern: {@link ExpressionStmt} -&gt; {@link Expression} ({@code expr}).
+   */
+  public static Optional<ExpressionStmt> isExpressionStmtExpr(final Expression expr) {
+    return expr.getParentNode()
+        .map(p -> p instanceof ExpressionStmt ? (ExpressionStmt) p : null)
+        .filter(stmt -> stmt.getExpression() == expr);
+  }
+
+  /**
    * Test for this pattern: {@link AssignExpr} -&gt; {@link Expression} ({@code expr}), where
    * ({@code expr}) is the right hand side expression of the assignment.
    */

--- a/framework/codemodder-base/src/main/java/io/codemodder/ast/LocalScope.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/ast/LocalScope.java
@@ -17,8 +17,6 @@ import com.github.javaparser.ast.stmt.ForEachStmt;
 import com.github.javaparser.ast.stmt.ForStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.stmt.TryStmt;
-
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -140,17 +138,20 @@ public final class LocalScope {
     return new LocalScope(expressions, statements);
   }
 
-  /** Calculates the scope of a Assignment {@link AssignExpr}. This function is currently incomplete as it only works if the AssignExpr is contained in an ExpressionStmt.*/
+  /**
+   * Calculates the scope of a Assignment {@link AssignExpr}. This function is currently incomplete
+   * as it only works if the AssignExpr is contained in an ExpressionStmt.
+   */
   public static LocalScope fromAssignExpression(AssignExpr aexpr) {
     var expressions = new NodeList<Expression>();
     var statements = new NodeList<Statement>();
     var maybeStmt = ASTs.isExpressionStmtExpr(aexpr);
-    if (maybeStmt.isPresent()){
-	    var block = (BlockStmt) maybeStmt.get().getParentNode().get();
-	    statements.setParentNode(block);
-	    block.getStatements().stream()
-		.skip(block.getStatements().indexOf(maybeStmt.get()) + 1)
-		.forEach(statements::add);
+    if (maybeStmt.isPresent()) {
+      var block = (BlockStmt) maybeStmt.get().getParentNode().get();
+      statements.setParentNode(block);
+      block.getStatements().stream()
+          .skip(block.getStatements().indexOf(maybeStmt.get()) + 1)
+          .forEach(statements::add);
     }
     return new LocalScope(expressions, statements);
   }

--- a/framework/codemodder-base/src/main/java/io/codemodder/ast/LocalScope.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/ast/LocalScope.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
@@ -16,6 +17,8 @@ import com.github.javaparser.ast.stmt.ForEachStmt;
 import com.github.javaparser.ast.stmt.ForStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.stmt.TryStmt;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -133,6 +136,21 @@ public final class LocalScope {
     }
     if (parent instanceof ConstructorDeclaration) {
       statements = ((ConstructorDeclaration) parent).getBody().getStatements();
+    }
+    return new LocalScope(expressions, statements);
+  }
+
+  /** Calculates the scope of a Assignment {@link AssignExpr}. This function is currently incomplete as it only works if the AssignExpr is contained in an ExpressionStmt.*/
+  public static LocalScope fromAssignExpression(AssignExpr aexpr) {
+    var expressions = new NodeList<Expression>();
+    var statements = new NodeList<Statement>();
+    var maybeStmt = ASTs.isExpressionStmtExpr(aexpr);
+    if (maybeStmt.isPresent()){
+	    var block = (BlockStmt) maybeStmt.get().getParentNode().get();
+	    statements.setParentNode(block);
+	    block.getStatements().stream()
+		.skip(block.getStatements().indexOf(maybeStmt.get()) + 1)
+		.forEach(statements::add);
     }
     return new LocalScope(expressions, statements);
   }


### PR DESCRIPTION
The SQL parameterizer codemod will now be able to apply the fix when the statement object originates from an assignment, e.g.:
```java
Statement stmt = null
try{
stmt = conn.createStatement();
stmt.executeQuery(...);
}
...
```
This unfortunately comes at the cost of breaking code whenever the assignment doesn't shadow the initiation. Since this particular case requires more sophisticated tools (mainly flow analysis), it is restricted for single assignments and the other cases stays as future work for now.