### PR TITLE
Add gpt-4-turbo model; use for code changing

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/LogFailedLoginCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/LogFailedLoginCodemod.java
@@ -68,7 +68,7 @@ public final class LogFailedLoginCodemod extends SarifToLLMForMultiOutcomeCodemo
                   """
                     .replace('\n', ' '))),
         StandardModel.GPT_4O_2024_05_13,
-        StandardModel.GPT_4_0613);
+        StandardModel.GPT_4_TURBO_2024_04_09);
   }
 
   @Override

--- a/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/SarifToLLMForBinaryVerificationAndFixingCodemod.java
+++ b/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/SarifToLLMForBinaryVerificationAndFixingCodemod.java
@@ -1,6 +1,6 @@
 package io.codemodder.plugins.llm;
 
-import static io.codemodder.plugins.llm.StandardModel.GPT_3_5_TURBO_0125;
+import static io.codemodder.plugins.llm.StandardModel.GPT_4_TURBO_2024_04_09;
 
 import com.azure.ai.openai.models.ChatRequestSystemMessage;
 import com.azure.ai.openai.models.ChatRequestUserMessage;
@@ -47,7 +47,7 @@ public abstract class SarifToLLMForBinaryVerificationAndFixingCodemod
    */
   protected SarifToLLMForBinaryVerificationAndFixingCodemod(
       final RuleSarif sarif, final OpenAIService openAI) {
-    this(sarif, openAI, GPT_3_5_TURBO_0125);
+    this(sarif, openAI, GPT_4_TURBO_2024_04_09);
   }
 
   @Override

--- a/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/SarifToLLMForMultiOutcomeCodemod.java
+++ b/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/SarifToLLMForMultiOutcomeCodemod.java
@@ -56,7 +56,7 @@ public abstract class SarifToLLMForMultiOutcomeCodemod extends SarifPluginRawFil
         openAI,
         remediationOutcomes,
         StandardModel.GPT_4O_2024_05_13,
-        StandardModel.GPT_4_0613);
+        StandardModel.GPT_4_TURBO_2024_04_09);
   }
 
   protected SarifToLLMForMultiOutcomeCodemod(

--- a/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/StandardModel.java
+++ b/plugins/codemodder-plugin-llm/src/main/java/io/codemodder/plugins/llm/StandardModel.java
@@ -17,6 +17,12 @@ public enum StandardModel implements Model {
       return Tokens.countTokens(messages, 3, EncodingType.CL100K_BASE);
     }
   },
+  GPT_4_TURBO_2024_04_09("gpt-4-turbo-2024-04-09", 128_000) {
+    @Override
+    public int tokens(final List<String> messages) {
+      return Tokens.countTokens(messages, 3, EncodingType.CL100K_BASE);
+    }
+  },
   GPT_4O_2024_05_13("gpt-4o-2024-05-13", 128_000) {
     /**
      * This is wrong - we copy / pasted from GPT 3.5 while we await GPT-4o token counting support <a


### PR DESCRIPTION
Without function calling, we need to use models that support `json_object` as a response format.

At some point we should revisit function calling with the new client, but it seems substantially more complicated than the old API. It also appears to be deprecated in favor of "tool calling"":

> For function call sample, see [function call](https://github.com/Azure/azure-sdk-for-java/tree/azure-ai-openai_1.0.0-beta.10/sdk/openai/azure-ai-openai/src/samples/java/com/azure/ai/openai/ChatCompletionsFunctionCall.java). However, they are considered a legacy feature. Using tools is the preferred way. For more details see sample [tool calls](https://github.com/Azure/azure-sdk-for-java/blob/azure-ai-openai_1.0.0-beta.10/sdk/openai/azure-ai-openai/src/samples/java/com/azure/ai/openai/usage/GetChatCompletionsToolCallSample.java).

https://learn.microsoft.com/en-us/java/api/overview/azure/ai-openai-readme?view=azure-java-preview#chat-completions