### PR TITLE
Skip SensitiveDataLoggingCodemod when LLM not available

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/SensitiveDataLoggingCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/SensitiveDataLoggingCodemod.java
@@ -119,6 +119,9 @@ public final class SensitiveDataLoggingCodemod extends JavaParserChanger {
 
   @Override
   public boolean shouldRun() {
+    if (!service.isServiceAvailable()) {
+      return false;
+    }
     List<Run> runs = sarif.rawDocument().getRuns();
     return runs != null && !runs.isEmpty() && !runs.get(0).getResults().isEmpty();
   }


### PR DESCRIPTION
This codemod does not inherit from the base class with the existing check so it did not benefit from the work in #418.