### PR TITLE
:sparkles: Support multiple rule names for AppScan

### DIFF
--- a/plugins/codemodder-plugin-appscan/src/main/java/io/codemodder/providers/sarif/appscan/AppScanModule.java
+++ b/plugins/codemodder-plugin-appscan/src/main/java/io/codemodder/providers/sarif/appscan/AppScanModule.java
@@ -41,10 +41,27 @@ public final class AppScanModule extends AbstractModule {
               .findFirst();
 
       annotation.ifPresent(
-          providedAppScanScan ->
+          providedAppScanScan -> {
+            if (!providedAppScanScan.ruleName().isEmpty()) {
               bind(RuleSarif.class)
                   .annotatedWith(providedAppScanScan)
-                  .toInstance(map.getOrDefault(providedAppScanScan.ruleName(), RuleSarif.EMPTY)));
+                  .toInstance(map.getOrDefault(providedAppScanScan.ruleName(), RuleSarif.EMPTY));
+            } else if (providedAppScanScan.ruleNames().length > 0) {
+
+              RuleSarif ruleSarif = RuleSarif.EMPTY;
+              for (final String ruleName : providedAppScanScan.ruleNames()) {
+                final var result = map.get(ruleName);
+                if (result != null) {
+                  ruleSarif = result;
+                  break;
+                }
+              }
+
+              bind(RuleSarif.class).annotatedWith(providedAppScanScan).toInstance(ruleSarif);
+            } else {
+              throw new IllegalStateException("No rule name provided in " + providedAppScanScan);
+            }
+          });
     }
   }
 }

--- a/plugins/codemodder-plugin-appscan/src/main/java/io/codemodder/providers/sarif/appscan/AppScanRuleSarif.java
+++ b/plugins/codemodder-plugin-appscan/src/main/java/io/codemodder/providers/sarif/appscan/AppScanRuleSarif.java
@@ -107,9 +107,9 @@ final class AppScanRuleSarif implements RuleSarif {
   }
 
   /**
-   * This returns the "ruleId" element, which has a value like "SA2813462719". The "message[text]"
-   * field has a more human-readable value like "SQL Injection". To stay aligned with other tools
-   * that use a more strict ID, we use the rule ID.
+   * This returns the "message[text]" field from the SARIF results. This is a human-readable value
+   * like "SQL Injection". We would ordinarily use this as the rule ID but this value is different
+   * each time we retrieve the SARIF for a given scan
    */
   @Override
   public String getRule() {

--- a/plugins/codemodder-plugin-appscan/src/main/java/io/codemodder/providers/sarif/appscan/ProvidedAppScanScan.java
+++ b/plugins/codemodder-plugin-appscan/src/main/java/io/codemodder/providers/sarif/appscan/ProvidedAppScanScan.java
@@ -14,5 +14,8 @@ import javax.inject.Qualifier;
 public @interface ProvidedAppScanScan {
 
   /** The AppScan rule name, which shows up as the "message text" in the SARIF results. */
-  String ruleName();
+  String ruleName() default "";
+
+  /** The AppScan rule names, which show up as the "message text" in the SARIF results. */
+  String[] ruleNames() default {};
 }


### PR DESCRIPTION
- **:sparkles: support muitiple rule names in AppScan**
- **:bulb: Improve docs for AppScan getRule accessor**
