### PR TITLE
Create result entries even when no changes

### DIFF
--- a/core-codemods/src/intTest/java/io/codemodder/integration/WebGoat822Test.java
+++ b/core-codemods/src/intTest/java/io/codemodder/integration/WebGoat822Test.java
@@ -52,8 +52,11 @@ final class WebGoat822Test extends GitRepositoryTest {
 
     verifyNoFailedFiles(report);
     List<CodeTFResult> results = report.getResults();
-    assertThat(results.size(), is(1));
-    CodeTFResult result = results.get(0);
+    CodeTFResult result =
+        results.stream()
+            .filter(r -> r.getCodemod().equals("pixee:java/harden-java-deserialization"))
+            .findFirst()
+            .orElseThrow();
     List<CodeTFChangesetEntry> changeset = result.getChangeset();
     assertThat(changeset.size(), is(3));
     assertThat(

--- a/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/CLI.java
@@ -447,9 +447,8 @@ final class CLI implements Callable<Integer> {
 
         log.info("running codemod: {}", codemod.getId());
         CodeTFResult result = codemodExecutor.execute(filePaths);
-        if (!result.getChangeset().isEmpty() || !result.getFailedFiles().isEmpty()) {
-          results.add(result);
-        }
+        results.add(result);
+
         if (!result.getChangeset().isEmpty()) {
           log.info("changed:");
           result


### PR DESCRIPTION
The primary purpose of this change is to enable the collection of codemod descriptions even when no actual changes are present. It also aligns codemodder-java with the existing behavior of codemodder-python.