### PR TITLE
Added check for existing overrides in add-missing-override

### DIFF
--- a/core-codemods/src/test/resources/add-missing-override-s1161/Test.java.after
+++ b/core-codemods/src/test/resources/add-missing-override-s1161/Test.java.after
@@ -144,6 +144,11 @@ public class SqlInjectionLesson10b extends AssignmentEndpoint {
     public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
       return contents;
     }
+
+    @Override
+    public CharSequence getCharContent2(boolean ignoreEncodingErrors) throws IOException {
+      return contents;
+    }
   }
 
   private boolean check_text(String regex, String text) {

--- a/core-codemods/src/test/resources/add-missing-override-s1161/Test.java.before
+++ b/core-codemods/src/test/resources/add-missing-override-s1161/Test.java.before
@@ -143,6 +143,11 @@ public class SqlInjectionLesson10b extends AssignmentEndpoint {
     public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
       return contents;
     }
+
+    @Override
+    public CharSequence getCharContent2(boolean ignoreEncodingErrors) throws IOException {
+      return contents;
+    }
   }
 
   private boolean check_text(String regex, String text) {

--- a/core-codemods/src/test/resources/add-missing-override-s1161/sonar-issues_1.json
+++ b/core-codemods/src/test/resources/add-missing-override-s1161/sonar-issues_1.json
@@ -45,6 +45,42 @@
           "severity": "MEDIUM"
         }
       ]
+    },
+    {
+      "key": "AYvtrjy0LCzGLicz7Ajy",
+      "rule": "java:S1161",
+      "severity": "MAJOR",
+      "component": "nahsra_WebGoat_10_23:src/main/java/SqlInjectionLesson10b.java",
+      "project": "nahsra_WebGoat_10_23",
+      "line": 148,
+      "hash": "e4d44f915becc09c0ce386b304b7621b",
+      "textRange": {
+        "startLine": 148,
+        "endLine": 148,
+        "startOffset": 24,
+        "endOffset": 39
+      },
+      "flows": [],
+      "status": "OPEN",
+      "message": "Add the \"@Override\" annotation above this method signature",
+      "effort": "5min",
+      "debt": "5min",
+      "author": "nanne.baars@owasp.org",
+      "tags": [
+        "bad-practice"
+      ],
+      "creationDate": "2022-04-09T14:56:12+0200",
+      "updateDate": "2023-11-20T17:58:54+0100",
+      "type": "CODE_SMELL",
+      "organization": "nahsra",
+      "cleanCodeAttribute": "CLEAR",
+      "cleanCodeAttributeCategory": "INTENTIONAL",
+      "impacts": [
+        {
+          "softwareQuality": "MAINTAINABILITY",
+          "severity": "MEDIUM"
+        }
+      ]
     }
   ],
   "components": [


### PR DESCRIPTION
If you have multiple findings of the same rule for the same location, some codemods will duplicate their fixes.

This PR adds a patch to stop this for the `add-missing-override` codemod.