### PR TITLE
Filter `DocumentBuilder#parse()` calls more accurately

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/remediation/NodePositionMatcher.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/remediation/NodePositionMatcher.java
@@ -5,7 +5,7 @@ import com.github.javaparser.ast.Node;
 /** Provides methods for matching nodes to given coordinates. */
 public interface NodePositionMatcher {
 
-  static final NodePositionMatcher DEFAULT = new DefaultNodePositionMatcher();
+  NodePositionMatcher DEFAULT = new DefaultNodePositionMatcher();
 
   /**
    * Matches a node with a range against a line

--- a/framework/codemodder-base/src/main/java/io/codemodder/remediation/xxe/DocumentBuilderFactoryAtParseFixStrategy.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/remediation/xxe/DocumentBuilderFactoryAtParseFixStrategy.java
@@ -101,6 +101,20 @@ final class DocumentBuilderFactoryAtParseFixStrategy extends MatchAndFixStrategy
         .map(n -> n instanceof MethodCallExpr ? (MethodCallExpr) n : null)
         .filter(m -> "parse".equals(m.getNameAsString()))
         .filter(m -> m.getScope().filter(Expression::isNameExpr).isPresent())
+        .filter(
+            m -> {
+              Optional<Node> sourceRef =
+                  ASTs.findNonCallableSimpleNameSource(m.getScope().get().asNameExpr().getName());
+              if (sourceRef.isEmpty()) {
+                return false;
+              }
+              Node source = sourceRef.get();
+              if (source instanceof NodeWithType<?, ?>) {
+                return Set.of("DocumentBuilder", "javax.xml.parsers.DocumentBuilder")
+                    .contains(((NodeWithType<?, ?>) source).getTypeAsString());
+              }
+              return false;
+            })
         .isPresent();
   }
 }


### PR DESCRIPTION
.. so it doesn't recognize `XMLReader#parse()` calls as well.