### PR TITLE
Don't throw exceptions if dependencies can't be pre-calculated

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DefaultCodemodExecutor.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -184,7 +185,14 @@ final class DefaultCodemodExecutor implements CodemodExecutor {
               Collection<DependencyGAV> deps =
                   projectProviders.stream()
                       .flatMap(
-                          provider -> provider.getAllDependencies(projectDir, filePath).stream())
+                          provider -> {
+                            try {
+                              return provider.getAllDependencies(projectDir, filePath).stream();
+                            } catch (Exception e) {
+                              log.error("Problem getting dependencies for file {}", filePath, e);
+                              return Stream.empty();
+                            }
+                          })
                       .toList();
 
               CodemodInvocationContext context =

--- a/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
+++ b/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
@@ -143,8 +143,9 @@ public final class MavenProvider implements ProjectProvider {
 
       return pomOperator.getAllFoundDependencies();
     } catch (Exception e) {
-      throw new DependencyUpdateException("Failure when retrieving dependencies", e);
+      LOG.warn("Not all Maven dependencies could be found", e);
     }
+    return Collections.emptyList();
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(MavenProvider.class);


### PR DESCRIPTION
We observed this issue:

```
INFO - 4abaf6cf-c5e6-4f48-b198-edc124aedf71 - Problem scanning file /tmp/codemodder-project6927415874030968841/app/src/main/java/org/apache/roller/weblogger/util/PasswordUtility.java
INFO - 4abaf6cf-c5e6-4f48-b198-edc124aedf71 - io.codemodder.plugins.maven.MavenProvider$DependencyUpdateException: Failure when retrieving dependencies
INFO - 4abaf6cf-c5e6-4f48-b198-edc124aedf71 - at io.codemodder.plugins.maven.MavenProvider.getAllDependencies(MavenProvider.java:146)
INFO - 4abaf6cf-c5e6-4f48-b198-edc124aedf71 - at io.codemodder.DefaultCodemodExecutor.lambda$execute$0(DefaultCodemodExecutor.java:187)
INFO - 4abaf6cf-c5e6-4f48-b198-edc124aedf71 - at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
INFO - 4abaf6cf-c5e6-4f48-b198-edc124aedf71 - at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
INFO - 4abaf6cf-c5e6-4f48-b198-edc124aedf71 - at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
...
io.codemodder.DefaultCodemodExecutor.lambda$execute$1(DefaultCodemodExecutor.java:188)
edc124aedf71 - Caused by: org.dom4j.DocumentException: Error on line 781 of document  : The element type "sequential" must be terminated by the matching end-tag "</sequential>".
```

This error is preventing _analysis_ from occurring, not the updating of Maven dependencies. We should still run our codemods, even if dependencies can't be pre-calculated. 