### PR TITLE
Disabled faulty empty element format preservation from POM operator

### DIFF
--- a/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/operator/FormatCommand.java
+++ b/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/operator/FormatCommand.java
@@ -508,21 +508,21 @@ class FormatCommand extends AbstractCommand {
 
     int lastIndex = 0;
 
-    singleElementsWithAttributes.sort(
-        Comparator.comparingInt(matchDataJ -> matchDataJ.getRange().getFirst()));
+    // singleElementsWithAttributes.sort(
+    //    Comparator.comparingInt(matchDataJ -> matchDataJ.getRange().getFirst()));
 
-    for (MatchData match : singleElementsWithAttributes) {
-      MatchResult representationMatch =
-          match.getModifiedContent().find(xmlRepresentation, lastIndex);
+    // for (MatchData match : singleElementsWithAttributes) {
+    //  MatchResult representationMatch =
+    //      match.getModifiedContent().find(xmlRepresentation, lastIndex);
 
-      if (null == representationMatch) {
-        LOGGER.warn("Failure on quoting: {}", match);
-      } else {
-        xmlRepresentation =
-            replaceRange(xmlRepresentation, representationMatch.getRange(), match.getContent());
-        lastIndex = representationMatch.getRange().getFirst() + match.getContent().length();
-      }
-    }
+    //  if (null == representationMatch) {
+    //    LOGGER.warn("Failure on quoting: {}", match);
+    //  } else {
+    //    xmlRepresentation =
+    //        replaceRange(xmlRepresentation, representationMatch.getRange(), match.getContent());
+    //    lastIndex = representationMatch.getRange().getFirst() + match.getContent().length();
+    //  }
+    // }
 
     /**
      * We might need to replace the beginning of the POM with the same content from the very

--- a/plugins/codemodder-plugin-maven/src/test/java/io/codemodder/plugins/maven/operator/POMOperatorTest.java
+++ b/plugins/codemodder-plugin-maven/src/test/java/io/codemodder/plugins/maven/operator/POMOperatorTest.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -589,6 +590,7 @@ final class POMOperatorTest extends AbstractTestBase {
    * validates the resulting POM structure.
    */
   @Test
+  @Disabled
   void modify_adds_dependency_to_pom_with_empty_elements_from_customer() throws Exception {
     Dependency dependencyToUpgrade =
         new Dependency("io.github.pixee", "java-security-toolkit", "1.0.2", null, null, null);


### PR DESCRIPTION
Removes a section of the code that deals with preserving formatting from self-closing/empty element from POM files.

Also disabled a test that asserts such format preservation.

This is meant to be a temporary change while we aim for a more permanent fix.