### PR TITLE
Changed default XML parser to Woodstox

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/DefaultXPathStreamProcessor.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DefaultXPathStreamProcessor.java
@@ -73,9 +73,14 @@ final class DefaultXPathStreamProcessor implements XPathStreamProcessor {
     XMLEventWriter xmlWriter = outputFactory.createXMLEventWriter(sw);
     while (xmlReader.hasNext()) {
       final XMLEvent currentEvent = xmlReader.nextEvent();
-      Location location = currentEvent.getLocation();
-      if (doesPositionMatch(httpMethodPositions, location)) {
-        handler.handle(xmlReader, xmlWriter, currentEvent);
+      // get the position of the last character of the event, that is, the start of the next one
+      if (xmlReader.hasNext()) {
+        Location location = xmlReader.peek().getLocation();
+        if (doesPositionMatch(httpMethodPositions, location)) {
+          handler.handle(xmlReader, xmlWriter, currentEvent);
+        } else {
+          xmlWriter.add(currentEvent);
+        }
       } else {
         xmlWriter.add(currentEvent);
       }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ picocli = "4.7.0"
 slf4j = "2.0.6"
 guice = "5.1.0"
 dom4j = "2.1.4"
+woodstox = "7.1.0"
 
 [libraries]
 autovalue-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "auto-value" }
@@ -27,6 +28,7 @@ contrast-sarif = "com.contrastsecurity:java-sarif:2.0"
 gson = "com.google.code.gson:gson:2.9.0"
 guice = { module = "com.google.inject:guice", version.ref = "guice" }
 immutables = "org.immutables:value:2.9.0"
+woodstox = { module = "com.fasterxml.woodstox:woodstox-core", version.ref = "woodstox" }
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 javadiff = "io.github.java-diff-utils:java-diff-utils:4.12"

--- a/plugins/codemodder-plugin-maven/build.gradle.kts
+++ b/plugins/codemodder-plugin-maven/build.gradle.kts
@@ -31,4 +31,5 @@ dependencies {
     implementation(libs.diff.match.patch)
     implementation(libs.slf4j.simple)
     implementation(libs.slf4j.api)
+    implementation(libs.woodstox)
 }

--- a/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
+++ b/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/MavenProvider.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>a. We skip parent finding if there's not a relativePath declaration (this is by design), so
  * sometimes pom finding will fail on purpose b. there are several flags on ProjectModelFactory
- * which aren't applied. They relate to verisons, upgrading and particularly: Actives Profiles c. If
+ * which aren't applied. They relate to versions, upgrading and particularly: Actives Profiles c. If
  * you need anything declared in a ~/.m2/settings.xml, we don't support that (e.g., passwords or
  * proxies) d. Haven't tested, but I'm almost sure that it wouldn't work on any repo other than
  * central e. We allow on this module to do online resolution. HOWEVER by default its offline f. You

--- a/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/operator/FormatCommand.java
+++ b/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/operator/FormatCommand.java
@@ -4,6 +4,7 @@ import static io.github.pixee.security.XMLInputFactorySecurity.hardenFactory;
 
 import com.ctc.wstx.evt.CompactStartElement;
 import com.ctc.wstx.stax.WstxInputFactory;
+import com.ctc.wstx.stax.WstxOutputFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,7 +44,7 @@ class FormatCommand extends AbstractCommand {
   private XMLInputFactory inputFactory = WstxInputFactory.newInstance();
 
   /** StAX OutputFactory */
-  private XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
+  private XMLOutputFactory outputFactory = WstxOutputFactory.newInstance();
 
   private List<MatchData> singleElementsWithAttributes = new ArrayList<>();
 
@@ -272,10 +273,6 @@ class FormatCommand extends AbstractCommand {
     int elementStart = 0;
     List<XMLEvent> prevEvents = new ArrayList<>();
 
-    System.out.println("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=");
-    System.out.println(inputFactory.getClass());
-    System.out.println(eventReader.getClass());
-    System.out.println("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=");
     while (eventReader.hasNext()) {
       XMLEvent event = eventReader.nextEvent();
 
@@ -331,7 +328,7 @@ class FormatCommand extends AbstractCommand {
               new String(pomFile.getOriginalPom(), pomFile.getCharset());
 
           String untrimmedOriginalContent = "";
-          // is self closing element, tag is contained within the offset of the next element
+          // is self-closing element, tag is contained within the offset of the next element
           if (prevEvents.get(prevEvents.size() - 1) instanceof CompactStartElement) {
             untrimmedOriginalContent =
                 originalPomCharsetString.substring(

--- a/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/operator/FormatCommand.java
+++ b/plugins/codemodder-plugin-maven/src/main/java/io/codemodder/plugins/maven/operator/FormatCommand.java
@@ -2,8 +2,6 @@ package io.codemodder.plugins.maven.operator;
 
 import static io.github.pixee.security.XMLInputFactorySecurity.hardenFactory;
 
-import com.ctc.wstx.stax.WstxInputFactory;
-import com.ctc.wstx.stax.WstxOutputFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,10 +38,10 @@ class FormatCommand extends AbstractCommand {
   private static final Logger LOGGER = LoggerFactory.getLogger(FormatCommand.class);
 
   /** StAX InputFactory */
-  private XMLInputFactory inputFactory = WstxInputFactory.newInstance();
+  private XMLInputFactory inputFactory = XMLInputFactory.newInstance().newInstance();
 
   /** StAX OutputFactory */
-  private XMLOutputFactory outputFactory = WstxOutputFactory.newInstance();
+  private XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
 
   private List<MatchData> singleElementsWithAttributes = new ArrayList<>();
 


### PR DESCRIPTION
Changes the default StAX parser to Woodstox. This will allow us to be more in control of the parser's behavior. Also it's a bit faster than Java's default one.