### PR TITLE
Deprioritize log injection

### DIFF
--- a/core-codemods/src/main/java/io/codemodder/codemods/codeql/CodeQLLogInjectionCodemod.java
+++ b/core-codemods/src/main/java/io/codemodder/codemods/codeql/CodeQLLogInjectionCodemod.java
@@ -16,7 +16,7 @@ import javax.inject.Inject;
     id = "codeql:java/log-injection",
     reviewGuidance = ReviewGuidance.MERGE_WITHOUT_REVIEW,
     importance = Importance.HIGH,
-    executionPriority = CodemodExecutionPriority.HIGH)
+    executionPriority = CodemodExecutionPriority.LOW)
 public final class CodeQLLogInjectionCodemod extends CodeQLRemediationCodemod {
 
   private final Remediator<Result> remediator;


### PR DESCRIPTION
This way, it runs "after" other codemods, and higher priority fixes will be merged first, in a conflict.