### PR TITLE
Injecting `java-security-toolkit:1.2.2` from codemods

### DIFF
--- a/framework/codemodder-base/src/main/java/io/codemodder/DependencyGAV.java
+++ b/framework/codemodder-base/src/main/java/io/codemodder/DependencyGAV.java
@@ -160,7 +160,7 @@ public interface DependencyGAV {
         group, artifact, version, justification, license, repositoryUrl, noTransitiveDependencies);
   }
 
-  String JAVA_SECURITY_TOOLKIT_VERSION = "1.2.1";
+  String JAVA_SECURITY_TOOLKIT_VERSION = "1.2.2";
   String JAVA_SECURITY_TOOLKIT_GAV =
       "io.github.pixee:java-security-toolkit:" + JAVA_SECURITY_TOOLKIT_VERSION;
 


### PR DESCRIPTION
For the codemods that inject the Java security toolkit, bump the version.